### PR TITLE
Xml-app-state-01: XML serialization and tests based on it

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,9 @@ project/target/
 .classpath
 .settings
 /base/bin/
+/base/.cache-main
+/base/.cache-tests
 /cli/bin/
+/cli/.cache-main
 /gui/bin/
+/gui/.cache-main

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,10 +9,10 @@
    include:
      - jdk: oraclejdk8
        scala: "2.11.7"
-       env: COMMAND="sbt clean coverage test" COMMAND2="sbt coverageAggregate"
+       env: COMMAND="sbt clean base/clean cli/clean gui/clean coverage base/test" COMMAND2="sbt coverageAggregate"
      - jdk: openjdk7
        scala: "2.11.7"
-       env: COMMAND="sbt clean base/coverage base/test" COMMAND2="sbt coverageAggregate"
+       env: COMMAND="sbt clean base/clean cli/clean gui/clean base/coverage base/test" COMMAND2="sbt coverageAggregate"
 
  script:
    - "$COMMAND && $COMMAND2"

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@
 #### Update Note for 0.2.X
  - XML format has been changed
    - Renamed elemet "txn" to "posting"
+   - Renamed element "txnGroup" to "txn"
    - Transaction dates are in extended ISO 8601 format
    - XML contains new top level element "appstate"
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,0 +1,17 @@
+## Release History
+
+### Current Release
+
+#### Update Note for 0.2.X
+ - XML format has been changed
+   - Renamed elemet "txn" to "posting"
+   - Transaction dates are in extended ISO 8601 format
+   - XML contains new top level element "appstate"
+
+
+#### fixes
+ - TBD
+
+#### additions
+ - TBD
+ 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,9 @@
    - Transaction dates are in extended ISO 8601 format
    - Account balance export in XML "abandon:balance"
 
+ - Clarified reporting and exporting (https://github.com/hrj/abandon/issues/71)
+   - Clarified meaning of "type": it could be either "journal" or "balance"
+   - New configuration keyword "format": which could be "ledger" or "xml"
 
 #### fixes
  - TBD

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,7 +5,7 @@
 #### Update Note for 0.3.0
  - XML format has been changed
    - New container element "abandon:journal"
-   - Renamed elemet "txn" to "posting"
+   - Renamed elemet "txn" to "post"
    - Renamed element "txnGroup" to "txn"
    - Transaction dates are in extended ISO 8601 format
    - Account balance export in XML "abandon:balance"

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,12 +2,13 @@
 
 ### Current Release
 
-#### Update Note for 0.2.X
+#### Update Note for 0.3.0
  - XML format has been changed
+   - New container element "abandon:journal"
    - Renamed elemet "txn" to "posting"
    - Renamed element "txnGroup" to "txn"
    - Transaction dates are in extended ISO 8601 format
-   - XML contains new top level element "appstate"
+   - Account balance export in XML "abandon:balance"
 
 
 #### fixes

--- a/base/src/main/scala/co/uproot/abandon/Ast.scala
+++ b/base/src/main/scala/co/uproot/abandon/Ast.scala
@@ -38,6 +38,10 @@ case class Date(year: Int, month: Int, day: Int) {
     f"$year%4d / $month%d / $day%d"
   }
 
+  def formatISO8601Ext = {
+    f"$year%4d-$month%02d-$day%02d"
+  }
+
   def formatCompactYYYYMMDD = {
     f"$year%4d/$month%d/$day%d"
   }

--- a/base/src/main/scala/co/uproot/abandon/Process.scala
+++ b/base/src/main/scala/co/uproot/abandon/Process.scala
@@ -97,9 +97,7 @@ case class AccountTreeState(name: AccountName, amount: BigDecimal, childStates: 
       </accounttree>
     }
     else {
-      <account cumulative={total.toString()} sum={amount.toString()}>
-        <name>{name.name}</name>
-        <fullpath>{name.fullPathStr}</fullpath>
+      <account sum={amount.toString()} cumulative={total.toString()} name={name.fullPathStr} >
         { childStates.sorted.map(_.toXML) }
       </account>
     }

--- a/base/src/main/scala/co/uproot/abandon/Process.scala
+++ b/base/src/main/scala/co/uproot/abandon/Process.scala
@@ -90,11 +90,19 @@ case class AccountTreeState(name: AccountName, amount: BigDecimal, childStates: 
   def compare(that: AccountTreeState) = this.name.fullPathStr.compare(that.name.fullPathStr)
 
   def toXML: xml.Node = {
+    if (name.fullPath.isEmpty) {
+      // This is root-node
+      <accounttree>
+        { childStates.sorted.map(_.toXML) }
+      </accounttree>
+    }
+    else {
       <account cumulative={total.toString()} sum={amount.toString()}>
         <name>{name.name}</name>
         <fullpath>{name.fullPathStr}</fullpath>
-      { childStates.sorted.map(_.toXML) }
+        { childStates.sorted.map(_.toXML) }
       </account>
+    }
   }
   def maxNameLength: Int = {
     math.max(name.name.length + name.depth * 2, if (childStates.nonEmpty) childStates.map(_.maxNameLength).max else 0)

--- a/base/src/main/scala/co/uproot/abandon/Process.scala
+++ b/base/src/main/scala/co/uproot/abandon/Process.scala
@@ -74,7 +74,7 @@ class AccountState {
 
 }
 
-case class AccountTreeState(name: AccountName, amount: BigDecimal, childStates: Seq[AccountTreeState]) {
+case class AccountTreeState(name: AccountName, amount: BigDecimal, childStates: Seq[AccountTreeState]) extends Ordered[AccountTreeState] {
   assert(amount != null)
   assert(childStates != null)
   lazy val total: BigDecimal = amount + childStates.foldLeft(Zero)(_ + _.total)
@@ -85,6 +85,16 @@ case class AccountTreeState(name: AccountName, amount: BigDecimal, childStates: 
   override def toString = {
     val indent = name.depth * 2
     (" " * indent) + name.name + ": " + amount + "(" + total + ")" + (if (childStates.length > 0) "\n" else "") + childStates.mkString("\n")
+  }
+
+  def compare(that: AccountTreeState) = this.name.fullPathStr.compare(that.name.fullPathStr)
+
+  def toXML: xml.Node = {
+      <account cumulative={total.toString()} sum={amount.toString()}>
+        <name>{name.name}</name>
+        <fullpath>{name.fullPathStr}</fullpath>
+      { childStates.sorted.map(_.toXML) }
+      </account>
   }
   def maxNameLength: Int = {
     math.max(name.name.length + name.depth * 2, if (childStates.nonEmpty) childStates.map(_.maxNameLength).max else 0)

--- a/base/src/main/scala/co/uproot/abandon/Report.scala
+++ b/base/src/main/scala/co/uproot/abandon/Report.scala
@@ -266,9 +266,9 @@ object Reports {
           { txnGroup.groupComments.map { comment => <comment>{ comment }</comment> } }
           {
             txnGroup.children.map(txn =>
-              <posting delta={ txn.delta.toString } name={ txn.name.fullPathStr }>{
+              <post delta={ txn.delta.toString } name={ txn.name.fullPathStr }>{
                 txn.commentOpt.map { comment => <comment>{ comment }</comment> }.getOrElse(xml.Null)
-             }</posting>)
+             }</post>)
           }
         </txn>
       }

--- a/base/src/main/scala/co/uproot/abandon/Report.scala
+++ b/base/src/main/scala/co/uproot/abandon/Report.scala
@@ -254,7 +254,7 @@ object Reports {
     </abandon>
   }
 
-  def xmlTxnExport(state: AppState, exportSettings: XmlExportSettings): xml.Node = {
+  def xmlJournalExport(state: AppState, exportSettings: XmlExportSettings): xml.Node = {
     <abandon>
       <journal>
        <transactions>{
@@ -277,6 +277,9 @@ object Reports {
    </abandon>
   }
   def xmlExport(state: AppState, exportSettings: XmlExportSettings): xml.Node = {
-    xmlTxnExport(state, exportSettings)
+    exportSettings.exportType match {
+      case JournalType => xmlJournalExport(state, exportSettings)
+      case BalanceType => xmlBalanceExport(state, exportSettings)
+    }
   }
 }

--- a/base/src/main/scala/co/uproot/abandon/Report.scala
+++ b/base/src/main/scala/co/uproot/abandon/Report.scala
@@ -246,14 +246,18 @@ object Reports {
     }
   }
 
-  def xmlExport(state: AppState, exportSettings: XmlExportSettings): xml.Node = {
+  def xmlBalanceExport(state: AppState, exportSettings: XmlExportSettings): xml.Node = {
     <abandon>
-       <appstate>
-        <accounttree>
-          { state.accState.mkTree({ x => true }).toXML }
-        </accounttree>
-      </appstate>
-      <transactions>{
+       <balance>
+          { state.accState.mkTree(exportSettings.isAccountMatching).toXML }
+       </balance>
+    </abandon>
+  }
+
+  def xmlTxnExport(state: AppState, exportSettings: XmlExportSettings): xml.Node = {
+    <abandon>
+      <journal>
+       <transactions>{
       val sortedGroups = state.accState.postGroups.sortBy(_.date.toInt)
       sortedGroups.map { txnGroup =>
         <txn date={ txnGroup.date.formatISO8601Ext }>
@@ -268,6 +272,11 @@ object Reports {
           }
         </txn>
       }
-    }</transactions></abandon>
+    }</transactions>
+    </journal>
+   </abandon>
+  }
+  def xmlExport(state: AppState, exportSettings: XmlExportSettings): xml.Node = {
+    xmlTxnExport(state, exportSettings)
   }
 }

--- a/base/src/main/scala/co/uproot/abandon/Report.scala
+++ b/base/src/main/scala/co/uproot/abandon/Report.scala
@@ -246,21 +246,27 @@ object Reports {
     }
   }
 
-  def xmlExport(state: AppState, exportSettings: ExportSettings): xml.Node = {
-    <abandon><transactions>{
+  def xmlExport(state: AppState, exportSettings: XmlExportSettings): xml.Node = {
+    <abandon>
+       <appstate>
+        <accounttree>
+          { state.accState.mkTree({ x => true }).toXML }
+        </accounttree>
+      </appstate>
+      <transactions>{
       val sortedGroups = state.accState.postGroups.sortBy(_.date.toInt)
       sortedGroups.map { txnGroup =>
-        <txnGroup date={ txnGroup.date.formatCompact }>
+        <txn date={ txnGroup.date.formatISO8601Ext }>
           { txnGroup.payeeOpt.map(payee => <payee>{ payee }</payee>).getOrElse(xml.Null) }
           { txnGroup.annotationOpt.map(annotation => <annotation>{ annotation }</annotation>).getOrElse(xml.Null) }
           { txnGroup.groupComments.map { comment => <comment>{ comment }</comment> } }
           {
             txnGroup.children.map(txn =>
-              <txn name={ txn.name.fullPathStr } delta={ txn.delta.toString }>{
+              <posting delta={ txn.delta.toString } name={ txn.name.fullPathStr }>{
                 txn.commentOpt.map { comment => <comment>{ comment }</comment> }.getOrElse(xml.Null)
-              }</txn>)
+             }</posting>)
           }
-        </txnGroup>
+        </txn>
       }
     }</transactions></abandon>
   }

--- a/base/src/test/scala/co/uproot/abandon/AstTest.scala
+++ b/base/src/test/scala/co/uproot/abandon/AstTest.scala
@@ -58,27 +58,32 @@ class AstTest extends FlatSpec with Matchers {
     val dates = List(
         Date(2013, 6, 1),
         Date(2014, 1, 10),
-        Date(2015, 11,12))
+        Date(2015, 11,12),
+        Date(2015, 12,31))
 
     val refCompactDates = List(
         "2013,6,1",
         "2014,1,10",
-        "2015,11,12")
+        "2015,11,12",
+        "2015,12,31")
 
     val refYYYYMMDD = List(
         "2013 / 6 / 1",
         "2014 / 1 / 10",
-        "2015 / 11 / 12")
+        "2015 / 11 / 12",
+        "2015 / 12 / 31")
 
     val refISO8601ExtDates = List(
         "2013-06-01",
         "2014-01-10",
-        "2015-11-12")
+        "2015-11-12",
+        "2015-12-31")
 
     val refCompactYYYYMMDD = List(
         "2013/6/1",
         "2014/1/10",
-        "2015/11/12")
+        "2015/11/12",
+        "2015/12/31")
 
     val months = List(
       Date(2013, 1, 1),

--- a/base/src/test/scala/co/uproot/abandon/AstTest.scala
+++ b/base/src/test/scala/co/uproot/abandon/AstTest.scala
@@ -70,6 +70,11 @@ class AstTest extends FlatSpec with Matchers {
         "2014 / 1 / 10",
         "2015 / 11 / 12")
 
+    val refISO8601ExtDates = List(
+        "2013-06-01",
+        "2014-01-10",
+        "2015-11-12")
+
     val refCompactYYYYMMDD = List(
         "2013/6/1",
         "2014/1/10",
@@ -110,6 +115,10 @@ class AstTest extends FlatSpec with Matchers {
 
     dates.zip(refCompactYYYYMMDD).forall({
         case (date, refDate) => date.formatCompactYYYYMMDD == refDate
+      }) should be(true)
+
+    dates.zip(refISO8601ExtDates).forall({
+        case (date, refDate) => date.formatISO8601Ext == refDate
       }) should be(true)
 
     dates.zip(refYYYYMMDD).forall({

--- a/base/src/test/scala/co/uproot/abandon/ComplexProcessTest.scala
+++ b/base/src/test/scala/co/uproot/abandon/ComplexProcessTest.scala
@@ -1,0 +1,35 @@
+package co.uproot.abandon
+
+import org.scalatest.FlatSpec
+import org.scalatest.matchers.Matcher
+import org.scalatest.Matchers
+import org.scalatest.Inside
+import java.lang.Exception
+
+import org.scalatest.StreamlinedXmlEquality._
+
+import TestHelper._
+import ParserHelper._
+		
+class ComplexProcessTest extends FlatSpec with Matchers with Inside {
+	"Abandon" should "handle simple xml test case without configuration" in {
+
+	  val (parseError, astEntries, processedFiles) = Processor.parseAll(Seq("testCases/small.ledger"))
+	  assert(!parseError)
+
+	  val xmlSettings = XmlExportSettings(None, Seq("balSheet12.txt"))
+	  val settings = Settings(Nil, Nil, Nil, Nil, ReportOptions(Nil), Seq(xmlSettings), None)
+
+	  val appState = Processor.process(astEntries,settings.accounts)
+	  //TODO: Processor.checkConstaints(appState, settings.eodConstraints)
+	  val xmlData = Reports.xmlExport(appState, xmlSettings)
+
+	  val prettyPrinter = new scala.xml.PrettyPrinter(1024,2)
+	  val refXML = scala.xml.XML.loadFile("testCases/refSmall.xml")
+	  
+	  //println(prettyPrinter.format(xmlData))
+	  //println(prettyPrinter.format(refXML))
+	  
+	  assert(xmlData === refXML)
+	}
+}

--- a/base/src/test/scala/co/uproot/abandon/ComplexProcessTest.scala
+++ b/base/src/test/scala/co/uproot/abandon/ComplexProcessTest.scala
@@ -31,8 +31,8 @@ class ComplexProcessTest extends FlatSpec with Matchers with Inside {
 	  val refXMLJournal = scala.xml.XML.loadFile("testCases/refSmallJournal.xml")
 	  
 	  //val prettyPrinter = new scala.xml.PrettyPrinter(1024,2)
-	  //println(prettyPrinter.format(xmlData))
-	  //println(prettyPrinter.format(refXML))
+	  //println(prettyPrinter.format(xmlJournal))
+	  //println(prettyPrinter.format(refXMLJournal))
 	  
 	  assert(xmlBalance === refXMLBalance)
 	  assert(xmlJournal === refXMLJournal)

--- a/base/src/test/scala/co/uproot/abandon/ComplexProcessTest.scala
+++ b/base/src/test/scala/co/uproot/abandon/ComplexProcessTest.scala
@@ -10,21 +10,22 @@ import org.scalatest.StreamlinedXmlEquality._
 
 import TestHelper._
 import ParserHelper._
-		
+
 class ComplexProcessTest extends FlatSpec with Matchers with Inside {
 	"Abandon" should "handle simple xml test case without configuration" in {
 
 	  val (parseError, astEntries, processedFiles) = Processor.parseAll(Seq("testCases/small.ledger"))
 	  assert(!parseError)
 
-	  val xmlSettings = XmlExportSettings(None, Seq("balSheet12.txt"))
-	  val settings = Settings(Nil, Nil, Nil, Nil, ReportOptions(Nil), Seq(xmlSettings), None)
+	  val xmlBalSettings = XmlExportSettings(BalanceType, None, Seq("not-used.xml"))
+	  val xmlTxnSettings = XmlExportSettings(JournalType, None, Seq("not-used.xml"))
+	  val settings = Settings(Nil, Nil, Nil, Nil, ReportOptions(Nil), Seq(xmlBalSettings), None)
 
 	  val appState = Processor.process(astEntries,settings.accounts)
 	  //TODO: Processor.checkConstaints(appState, settings.eodConstraints)
 
-	  val xmlBalance = Reports.xmlBalanceExport(appState, xmlSettings)
-	  val xmlJournal = Reports.xmlTxnExport(appState, xmlSettings)
+	  val xmlBalance = Reports.xmlExport(appState, xmlBalSettings)
+	  val xmlJournal = Reports.xmlExport(appState, xmlTxnSettings)
 
 	  val refXMLBalance = scala.xml.XML.loadFile("testCases/refSmallBalance.xml")
 	  val refXMLJournal = scala.xml.XML.loadFile("testCases/refSmallJournal.xml")

--- a/base/src/test/scala/co/uproot/abandon/ComplexProcessTest.scala
+++ b/base/src/test/scala/co/uproot/abandon/ComplexProcessTest.scala
@@ -22,14 +22,18 @@ class ComplexProcessTest extends FlatSpec with Matchers with Inside {
 
 	  val appState = Processor.process(astEntries,settings.accounts)
 	  //TODO: Processor.checkConstaints(appState, settings.eodConstraints)
-	  val xmlData = Reports.xmlExport(appState, xmlSettings)
 
-	  val prettyPrinter = new scala.xml.PrettyPrinter(1024,2)
-	  val refXML = scala.xml.XML.loadFile("testCases/refSmall.xml")
+	  val xmlBalance = Reports.xmlBalanceExport(appState, xmlSettings)
+	  val xmlJournal = Reports.xmlTxnExport(appState, xmlSettings)
+
+	  val refXMLBalance = scala.xml.XML.loadFile("testCases/refSmallBalance.xml")
+	  val refXMLJournal = scala.xml.XML.loadFile("testCases/refSmallJournal.xml")
 	  
+	  //val prettyPrinter = new scala.xml.PrettyPrinter(1024,2)
 	  //println(prettyPrinter.format(xmlData))
 	  //println(prettyPrinter.format(refXML))
 	  
-	  assert(xmlData === refXML)
+	  assert(xmlBalance === refXMLBalance)
+	  assert(xmlJournal === refXMLJournal)
 	}
 }

--- a/build.sbt
+++ b/build.sbt
@@ -14,7 +14,7 @@ excludedJars in assembly <<= (fullClasspath in assembly) map { cp =>
 
 name := "abandon"
 
-version := "0.2.1"
+version := "0.3.0-dev"
 
 scalaVersion in ThisBuild := "2.11.7"
 

--- a/cli/src/main/scala/co/uproot/abandon/App.scala
+++ b/cli/src/main/scala/co/uproot/abandon/App.scala
@@ -152,7 +152,7 @@ object AbandonApp extends App {
                 val ledgerRep = Reports.ledgerExport(appState, settings, balSettings)
                 exportAsLedger(reportWriter, ledgerRep)
               case xmlSettings: XmlExportSettings =>
-                val xmlData = Reports.xmlExport(appState, exportSettings)
+                val xmlData = Reports.xmlExport(appState, xmlSettings)
                 reportWriter.printXml(xmlData)
             }
             reportWriter.close

--- a/examples/complete/accounts.conf
+++ b/examples/complete/accounts.conf
@@ -46,12 +46,19 @@ reports += {
 }
 
 exports += {
-  type = xml
+  type = journal
+  format = xml
   outFiles = [txns.xml]
+}
+exports += {
+  type = balance
+  format = xml
+  outFiles = [balance.xml]
 }
 
 exports += {
-  type = ledger
+  type = journal
+  format = ledger
   outFiles = [closing.ledger]
 
   closures = [{

--- a/testCases/refSmall.xml
+++ b/testCases/refSmall.xml
@@ -1,0 +1,24 @@
+<abandon>
+  <appstate>
+    <accounttree>
+      <account cumulative="0" sum="0">
+        <name/>
+        <fullpath/>
+        <account cumulative="-400" sum="-400">
+          <name>Assets</name>
+          <fullpath>Assets</fullpath>
+        </account>
+        <account cumulative="400" sum="400">
+          <name>Expenses</name>
+          <fullpath>Expenses</fullpath>
+        </account>
+      </account>
+    </accounttree>
+  </appstate>
+  <transactions>
+    <txn date="2013-04-01">
+      <posting delta="400" name="Expenses"/>
+      <posting delta="-400" name="Assets"/>
+    </txn>
+  </transactions>
+</abandon>

--- a/testCases/refSmallBalance.xml
+++ b/testCases/refSmallBalance.xml
@@ -1,8 +1,13 @@
 <abandon>
   <balance>
     <accounttree>
-      <account sum="-400" cumulative="-400" name="Assets"> </account>
-      <account sum="400" cumulative="400" name="Expenses"> </account>
+      <account sum="-2000" cumulative="-2000" name="Assets"> </account>
+      <account sum="400" cumulative="2000" name="Expenses">
+        <account sum="400" cumulative="400" name="Expenses:X"> </account>
+        <account sum="400" cumulative="1200" name="Expenses:e">
+          <account sum="800" cumulative="800" name="Expenses:e:d"> </account>
+        </account>
+      </account>
     </accounttree>
   </balance>
 </abandon>

--- a/testCases/refSmallBalance.xml
+++ b/testCases/refSmallBalance.xml
@@ -1,14 +1,8 @@
 <abandon>
   <balance>
     <accounttree>
-        <account cumulative="-400" sum="-400">
-          <name>Assets</name>
-          <fullpath>Assets</fullpath>
-        </account>
-        <account cumulative="400" sum="400">
-          <name>Expenses</name>
-          <fullpath>Expenses</fullpath>
-        </account>
+      <account sum="-400" cumulative="-400" name="Assets"> </account>
+      <account sum="400" cumulative="400" name="Expenses"> </account>
     </accounttree>
   </balance>
 </abandon>

--- a/testCases/refSmallBalance.xml
+++ b/testCases/refSmallBalance.xml
@@ -1,9 +1,6 @@
 <abandon>
-  <appstate>
+  <balance>
     <accounttree>
-      <account cumulative="0" sum="0">
-        <name/>
-        <fullpath/>
         <account cumulative="-400" sum="-400">
           <name>Assets</name>
           <fullpath>Assets</fullpath>
@@ -12,13 +9,6 @@
           <name>Expenses</name>
           <fullpath>Expenses</fullpath>
         </account>
-      </account>
     </accounttree>
-  </appstate>
-  <transactions>
-    <txn date="2013-04-01">
-      <posting delta="400" name="Expenses"/>
-      <posting delta="-400" name="Assets"/>
-    </txn>
-  </transactions>
+  </balance>
 </abandon>

--- a/testCases/refSmallJournal.xml
+++ b/testCases/refSmallJournal.xml
@@ -1,11 +1,37 @@
 <abandon>
   <journal>
-  <transactions>
-    <txn date="2013-04-01">
-      <posting delta="400" name="Expenses"/>
-      <posting delta="-400" name="Assets"/>
-    </txn>
-  </transactions>
+    <transactions>
+      <txn date="2013-04-01">
+        <post delta="400" name="Expenses"></post>
+        <post delta="-400" name="Assets"></post>
+      </txn>
+      <txn date="2013-04-02">
+        <annotation>123</annotation>
+        <post delta="400" name="Expenses:e"></post>
+        <post delta="-400" name="Assets"></post>
+      </txn>
+      <txn date="2013-04-02">
+        <payee>txn description</payee>
+        <annotation>123</annotation>
+        <post delta="400" name="Expenses:e:d"></post>
+        <post delta="-400" name="Assets"></post>
+      </txn>
+      <txn date="2013-04-02">
+        <payee>txn comment</payee>
+        <annotation>123</annotation>
+        <comment>txn comment</comment>
+        <post delta="400" name="Expenses:e:d"></post>
+        <post delta="-400" name="Assets"></post>
+      </txn>
+      <txn date="2013-04-02">
+        <payee>txn with everything</payee>
+        <annotation>123</annotation>
+        <comment>this is txn comment</comment>
+        <post delta="400" name="Expenses:X">
+          <comment>this is post comment</comment>
+        </post>
+        <post delta="-400" name="Assets"></post>
+      </txn>
+    </transactions>
   </journal>
 </abandon>
-

--- a/testCases/refSmallJournal.xml
+++ b/testCases/refSmallJournal.xml
@@ -1,0 +1,11 @@
+<abandon>
+  <journal>
+  <transactions>
+    <txn date="2013-04-01">
+      <posting delta="400" name="Expenses"/>
+      <posting delta="-400" name="Assets"/>
+    </txn>
+  </transactions>
+  </journal>
+</abandon>
+

--- a/testCases/small.conf
+++ b/testCases/small.conf
@@ -1,0 +1,23 @@
+inputs += small.ledger
+
+reportOptions = {
+  isRight = [Liability, Capital, Income]
+}
+
+reports += {
+  title = "Profit and Loss" 
+  type = balance
+  accountMatch = ["^Assets.*", "^Expenses.*"]
+}
+
+exports += {
+  type = balance
+  format = xml
+  outFiles = [balance.xml]
+}
+
+exports += {
+  type = journal
+  format = xml
+  outFiles = [journal.xml]
+}

--- a/testCases/small.ledger
+++ b/testCases/small.ledger
@@ -1,0 +1,5 @@
+2013/4/1
+  Expenses                   400
+  Assets
+
+

--- a/testCases/small.ledger
+++ b/testCases/small.ledger
@@ -2,4 +2,20 @@
   Expenses                   400
   Assets
 
+2013/4/2 (123)
+  Expenses:e                 400
+  Assets
 
+2013/4/2 (123) txn description
+  Expenses:e:d               400
+  Assets
+
+2013/4/2 (123) txn comment
+  ;txn comment
+  Expenses:e:d               400
+  Assets
+
+2013/4/2 (123) txn with everything
+  ;this is txn comment
+  Expenses:X                 400 ;this is post comment
+  Assets


### PR DESCRIPTION
Hello, 

This pull request extend xmlReport in a way that it can be used for serialization with tests. 
Added appstate information is also useful by itself, because it could be used to report summaries of whole account tree, not only transactions.

This pull request also contains a non-compatible change with XML formating by renaming "txn" to "posting" and "txnGroup" to "txn".
It could be good idea to clean up terminology and use consistently txn or transaction for transactions, and posting for rows with account and deltas. This would  also be in line with terminology of ledger-cli. https://github.com/ledger/ledger/wiki/Terminology

If you thing think this general txnGroup -> txn/Transaction (AST:Transcation -> ASTTransaction) and DetailedPost -> Posting refactoring would make sense, I could do that change later.

This pull request increases statement coverage to 49%. 
I hope this is OK, despite those XML changes.