### PR TITLE
Fix for #72: output get duplicated with stdout.

### DIFF
--- a/cli/src/main/scala/co/uproot/abandon/App.scala
+++ b/cli/src/main/scala/co/uproot/abandon/App.scala
@@ -53,7 +53,7 @@ final class ReportWriter(settings: Settings, outFiles: Seq[String]) {
     }
 
     if (writesToScreen) {
-      println(sb.toString)
+      Console.println(sb.toString)
     }
   }
 


### PR DESCRIPTION
This is same fix for #72 than with 1b53abc9, but cleanly against mainline.