### PR TITLE
tests-use-it-word: Use "it" word with unit tests. No functional changes.

### DIFF
--- a/base/src/test/scala/co/uproot/abandon/AstTest.scala
+++ b/base/src/test/scala/co/uproot/abandon/AstTest.scala
@@ -11,14 +11,14 @@ class AstTest extends FlatSpec with Matchers {
     testDate.toInt should be(20160102)
   }
 
-  "Date" should "be possible to convert from int" in {  
+  it should "be possible to convert from int" in {
     val testDate = Date.fromInt(20160102)
     testDate.year should be(2016)
     testDate.month should be(1)
     testDate.day should be (2)
   }
   
-  "Dates" should "compare correctly" in {
+  it should "compare correctly" in {
     import scala.util.Sorting
 
     val dates = List(
@@ -53,7 +53,7 @@ class AstTest extends FlatSpec with Matchers {
       }) should be(true)
   }
 
-  "Dates" should "format correctly" in {
+  it should "format correctly" in {
 
     val dates = List(
         Date(2013, 6, 1),

--- a/base/src/test/scala/co/uproot/abandon/ParserTest.scala
+++ b/base/src/test/scala/co/uproot/abandon/ParserTest.scala
@@ -9,7 +9,7 @@ import TestHelper._
 
 class ParserTest extends FlatSpec with Matchers with Inside {
 
-  "parser" should "parse empty file" in {
+  "Parser" should "parse empty file" in {
     val testInput = ""
     val parseResult = AbandonParser.abandon(scanner(testInput))
     inside(parseResult) {
@@ -18,7 +18,7 @@ class ParserTest extends FlatSpec with Matchers with Inside {
     }
   }
 
-  "parser" should "parse a simple transaction" in {
+  it should "parse a simple transaction" in {
     val testInput = """
     2013/1/2
       Expense       200
@@ -45,7 +45,7 @@ class ParserTest extends FlatSpec with Matchers with Inside {
     }
   }
 
-  "parser" should "parse a simple transaction with ISO 8601 date" in {
+  it should "parse a simple transaction with ISO 8601 date" in {
     val testInput = """
     2013-01-02
       Expense       200
@@ -72,7 +72,7 @@ class ParserTest extends FlatSpec with Matchers with Inside {
     }
   }
 
-  "parser" should "parse human readable dates and more than two posts in a transaction" in {
+  it should "parse human readable dates and more than two posts in a transaction" in {
     val testInput = """
     2013/March/1
       Expense       200
@@ -102,7 +102,7 @@ class ParserTest extends FlatSpec with Matchers with Inside {
     }
   }
 
-  "parser" should "parse short human readable dates and posts with empty value field" in {
+  it should "parse short human readable dates and posts with empty value field" in {
     val testInput = """
     2013/Mar/1
       Expense       200
@@ -151,7 +151,7 @@ class ParserTest extends FlatSpec with Matchers with Inside {
     }
   }
 
-  "parser" should "parse a simple expression" in {
+  it should "parse a simple expression" in {
     val testInput = """
     2013/1/2
       Expense       -(200 + 40)
@@ -179,7 +179,7 @@ class ParserTest extends FlatSpec with Matchers with Inside {
     }
   }
 
-  "parser" should "parse posts with zero value" in {
+  it should "parse posts with zero value" in {
     val testInput = """
     2013/1/1
       Expense       200
@@ -221,7 +221,7 @@ class ParserTest extends FlatSpec with Matchers with Inside {
     }
   }
 
-  "parser" should "parse a post with Unary plus(+) zero value" in {
+  it should "parse a post with Unary plus(+) zero value" in {
     val testInput = """
      2013/9/1
       Expense       200
@@ -252,7 +252,7 @@ class ParserTest extends FlatSpec with Matchers with Inside {
     }
   }
 
-  "parser" should "parse a post with Unary minus(-) zero value" in {
+  it should "parse a post with Unary minus(-) zero value" in {
     val testInput = """
       2013/9/1
        Expense       200
@@ -286,7 +286,7 @@ class ParserTest extends FlatSpec with Matchers with Inside {
     }
   }
 
-  "parser" should "parse a simple subtraction expression" in {
+  it should "parse a simple subtraction expression" in {
     val testInput = """
     2013/1/1
       Expense       200-4
@@ -324,7 +324,7 @@ class ParserTest extends FlatSpec with Matchers with Inside {
 
   def bd(s: String) = BigDecimal(s)
 
-  "parser" should "parse simple numeric expression" in {
+  it should "parse simple numeric expression" in {
     val tests = Map(
       "0001" -> (bd("1") -> nlit(1)),
       "000" -> (bd("0") -> nlit(0)),
@@ -348,7 +348,7 @@ class ParserTest extends FlatSpec with Matchers with Inside {
     }
   }
 
-  "parser" should "parse complex numeric expression" in {
+  it should "parse complex numeric expression" in {
     val tests = Map(
       "0001 + 10.00" -> (bd("11"), AddExpr(nlit(1), nlit(10.00))),
       "10.5 - (2.5 * 2)" -> (bd("5.5"), SubExpr(nlit(10.5), MulExpr(nlit(2.5), nlit(2)))),
@@ -377,7 +377,7 @@ class ParserTest extends FlatSpec with Matchers with Inside {
     }
   }
 
-  "parser" should "do something about divide by zero" in {
+  it should "do something about divide by zero" in {
     val tests = Map(
       "1 / 0" -> (bd("0"), DivExpr(nlit(1), nlit(0)))
     )
@@ -401,7 +401,7 @@ class ParserTest extends FlatSpec with Matchers with Inside {
     }
   }
 
-  "parser" should "ensure precedence of operators" in {
+  it should "ensure precedence of operators" in {
     val tests = Map(
       "1 + 2 * 3" -> (bd("7"), AddExpr(nlit(1), MulExpr(nlit(2), nlit(3)))),
       "1 * 2 + 3" -> (bd("5"), AddExpr(MulExpr(nlit(1), nlit(2)), nlit(3))),
@@ -432,7 +432,7 @@ class ParserTest extends FlatSpec with Matchers with Inside {
     }
   }
 
-  "parser" should "handle parenthesis correctly" in {
+  it should "handle parenthesis correctly" in {
     val tests = Map(
       "1 + (2 * 3)" -> (bd("7"), AddExpr(nlit(1), MulExpr(nlit(2), nlit(3)))),
       "(1 + 2) * 3" -> (bd("9"), MulExpr(AddExpr(nlit(1), nlit(2)), nlit(3))),
@@ -457,7 +457,7 @@ class ParserTest extends FlatSpec with Matchers with Inside {
     }
   }
 
-  "parser" should "parse month names in date" in {
+  it should "parse month names in date" in {
     val testInput = List(
       "2013/January/1",
       "2013/january/1",
@@ -477,7 +477,7 @@ class ParserTest extends FlatSpec with Matchers with Inside {
 
   }
 
-  "parser" should "parse dates in ISO 8601" in {
+  it should "parse dates in ISO 8601" in {
     val testInput = List(
       "2013-01-02"
     )

--- a/base/src/test/scala/co/uproot/abandon/ProcessorTest.scala
+++ b/base/src/test/scala/co/uproot/abandon/ProcessorTest.scala
@@ -40,7 +40,7 @@ class ProcessorTest extends FlatSpec with Matchers with Inside {
     }
   }
 
-  "Processor" should "not export a transaction with zero value when showZeroAmount is False" in {
+  it should "not export a transaction with zero value when showZeroAmount is False" in {
     val testInput = """
     2013/1/1
       Expense       -(200 + 40)
@@ -70,7 +70,7 @@ class ProcessorTest extends FlatSpec with Matchers with Inside {
     }
   }
 
-  "Processor" should "export a transaction with zero value when showZeroAmount is True" in {
+  it should "export a transaction with zero value when showZeroAmount is True" in {
     val testInput = """
     2013/1/1
       Expense       -200
@@ -102,7 +102,7 @@ class ProcessorTest extends FlatSpec with Matchers with Inside {
     }
   }
 
-  "Processor" should "export no transaction for empty input" in {
+  it should "export no transaction for empty input" in {
     val testInput = """
     """
     val parseResult = AbandonParser.abandon(scanner(testInput))
@@ -118,7 +118,7 @@ class ProcessorTest extends FlatSpec with Matchers with Inside {
     }
   }
 
-  "Processor" should "export transaction with closing balance" in {
+  it should "export transaction with closing balance" in {
     val testInput = """
       2013/1/1
       Expense       4000
@@ -168,7 +168,7 @@ class ProcessorTest extends FlatSpec with Matchers with Inside {
 
   }
 
-  "Processor" should "show Exception when 'source' contains same 'accountName'" in {
+  it should "show Exception when 'source' contains same 'accountName'" in {
     val testInput = """
       2013/1/1
       Expense       4000
@@ -198,7 +198,7 @@ class ProcessorTest extends FlatSpec with Matchers with Inside {
 
   }
 
-  "Processor" should "show Exception when 'destination' is not Present" in {
+  it should "show Exception when 'destination' is not Present" in {
     val testInput = """
       2013/1/1
       Expense       14000
@@ -223,7 +223,7 @@ class ProcessorTest extends FlatSpec with Matchers with Inside {
     }
   }
 
-  "Processor" should "show Exception when 'destination' is present in 'source'" in {
+  it should "show Exception when 'destination' is present in 'source'" in {
     val testInput = """
       2013/1/1
       Expense       14000
@@ -249,7 +249,7 @@ class ProcessorTest extends FlatSpec with Matchers with Inside {
 
   }
 
-  "Processor" should "process Alias name" in {
+  it should "process Alias name" in {
     val testInput = """
       2013/1/1
       MyBank       14000


### PR DESCRIPTION
This cleans and halves amount of printed test output lines and makes output look neat.