### PR TITLE
Testrunner-with-args

### DIFF
--- a/cli/src/test/scala/co/uproot/abandon/CliTestRunner.scala
+++ b/cli/src/test/scala/co/uproot/abandon/CliTestRunner.scala
@@ -40,8 +40,11 @@ class CliTestRunner extends FlatSpec with Matchers with Inside {
         val ref = rf.toPath.getFileName.toString()
         val output = "out." + basename + "." + ref.stripPrefix(basename + ".ref.")
 
-        // Remove old output files - these can potentially mask test failures
-        Files.deleteIfExists(Paths.get(testDir.toString, output))
+        /*
+         * Old output files - these can potentially mask test failures
+         * Let's err on safe side and not delete files for now.
+         * TODO: Use conditionally in memory file system for output
+         */
 
         if (ref.endsWith(".xml")) {
           TestVec(testDir.toString + "/" + output,

--- a/cli/src/test/scala/co/uproot/abandon/CliTestRunner.scala
+++ b/cli/src/test/scala/co/uproot/abandon/CliTestRunner.scala
@@ -14,59 +14,58 @@ import java.nio.file.Paths
 
 class CliTestRunner extends FlatSpec with Matchers with Inside {
 
-	"Testrunner" should "automatically test multiple dirs and confs" in {
-	  
-	  val testConfs = 
-	      for (d <- FileUtils.listDirs("testCases", ".*/sclT[0-9]+(-.*)$")) yield {  
-	        for (f <- FileUtils.listFiles(d.getAbsolutePath, ".*\\.conf$")) 
-	          yield { f } 
-	      }
-	  
-	  val testCases = for (f <- testConfs.flatten) yield {
-	      val testDir = f.toPath.getParent
-	      val basename = f.toPath.getFileName.toString.stripSuffix(".conf")
+  "Testrunner" should "automatically test multiple dirs and confs" in {
 
-        val argsPath = Paths.get(testDir.toString, basename + ".args")
-        val args =
-          if (Files.isReadable(argsPath)) {
-            val source = io.Source.fromFile(argsPath.toString)
-            try source.getLines.map(str => str.trim).toArray finally source.close
-          } else {
-            Array[String]()
-          }
+    val testConfs =
+      for (d <- FileUtils.listDirs("testCases", ".*/sclT[0-9]+(-.*)$")) yield {
+        for (f <- FileUtils.listFiles(d.getAbsolutePath, ".*\\.conf$")) yield { f }
+      }
 
-	      val refFiles = FileUtils.listFiles(testDir.toString , ".*/" + basename + "\\.ref\\..*")
-	      
-	      val testVecs = for (rf <- refFiles) yield {
-	        val ref = rf.toPath.getFileName.toString()
-	        val output = "out." + basename + "." + ref.stripPrefix(basename + ".ref.")
+    val testCases = for (f <- testConfs.flatten) yield {
+      val testDir = f.toPath.getParent
+      val basename = f.toPath.getFileName.toString.stripSuffix(".conf")
 
-	        // Remove old output files - these can potentially mask test failures
-	        Files.deleteIfExists(Paths.get(testDir.toString, output))
+      val argsPath = Paths.get(testDir.toString, basename + ".args")
+      val args =
+        if (Files.isReadable(argsPath)) {
+          val source = io.Source.fromFile(argsPath.toString)
+          try source.getLines.map(str => str.trim).toArray finally source.close
+        } else {
+          Array[String]()
+        }
 
-	        if (ref.endsWith(".xml")) {
-	          TestVec(testDir.toString + "/" + output,
-	               testDir.toString + "/" + ref, TestComparator.xmlComparator)
-	        } else {
-	          TestVec(testDir.toString + "/" + output,
-	              testDir.toString + "/" + ref, TestComparator.txtComparator)
-	        }
-	      }
-	      TestCase(f.toPath().toString, args, testVecs.toList)
-	  }
-	  
-	  for (tc <- testCases) {
-            try {
-	       co.uproot.abandon.CLIMain.runAppThrows(Array("-c", tc.conf) ++ tc.args)
-	    } catch {
-               case _: Throwable => assert(false)
-            }
-	    for (testfiles <- tc.testVec) {
-	      println("reference: " + testfiles.reference)
-	      println("output:    " + testfiles.output)
-	      
-	      assert(testfiles.comparator(testfiles.output, testfiles.reference))
-	    }
-	  }
-	}
+      val refFiles = FileUtils.listFiles(testDir.toString, ".*/" + basename + "\\.ref\\..*")
+
+      val testVecs = for (rf <- refFiles) yield {
+        val ref = rf.toPath.getFileName.toString()
+        val output = "out." + basename + "." + ref.stripPrefix(basename + ".ref.")
+
+        // Remove old output files - these can potentially mask test failures
+        Files.deleteIfExists(Paths.get(testDir.toString, output))
+
+        if (ref.endsWith(".xml")) {
+          TestVec(testDir.toString + "/" + output,
+            testDir.toString + "/" + ref, TestComparator.xmlComparator)
+        } else {
+          TestVec(testDir.toString + "/" + output,
+            testDir.toString + "/" + ref, TestComparator.txtComparator)
+        }
+      }
+      TestCase(f.toPath().toString, args, testVecs.toList)
+    }
+
+    for (tc <- testCases) {
+      try {
+        co.uproot.abandon.CLIMain.runAppThrows(Array("-c", tc.conf) ++ tc.args)
+      } catch {
+        case _: Throwable => assert(false)
+      }
+      for (testfiles <- tc.testVec) {
+        println("reference: " + testfiles.reference)
+        println("output:    " + testfiles.output)
+
+        assert(testfiles.comparator(testfiles.output, testfiles.reference))
+      }
+    }
+  }
 }

--- a/cli/src/test/scala/co/uproot/abandon/CliTestRunner.scala
+++ b/cli/src/test/scala/co/uproot/abandon/CliTestRunner.scala
@@ -9,6 +9,8 @@ import org.scalatest.StreamlinedXmlEquality._
 import TestComparator._
 
 import java.io.File
+import java.nio.file.Files
+import java.nio.file.Paths
 
 class CliTestRunner extends FlatSpec with Matchers with Inside {
 
@@ -23,26 +25,39 @@ class CliTestRunner extends FlatSpec with Matchers with Inside {
 	  val testCases = for (f <- testConfs.flatten) yield {
 	      val testDir = f.toPath.getParent
 	      val basename = f.toPath.getFileName.toString.stripSuffix(".conf")
+
+        val argsPath = Paths.get(testDir.toString, basename + ".args")
+        val args =
+          if (Files.isReadable(argsPath)) {
+            val source = io.Source.fromFile(argsPath.toString)
+            try source.getLines.map(str => str.trim).toArray finally source.close
+          } else {
+            Array[String]()
+          }
+
 	      val refFiles = FileUtils.listFiles(testDir.toString , ".*/" + basename + "\\.ref\\..*")
 	      
 	      val testVecs = for (rf <- refFiles) yield {
 	        val ref = rf.toPath.getFileName.toString()
 	        val output = "out." + basename + "." + ref.stripPrefix(basename + ".ref.")
-	        
-	        if (ref.endsWith(".xml"))
+
+	        // Remove old output files - these can potentially mask test failures
+	        Files.deleteIfExists(Paths.get(testDir.toString, output))
+
+	        if (ref.endsWith(".xml")) {
 	          TestVec(testDir.toString + "/" + output,
 	               testDir.toString + "/" + ref, TestComparator.xmlComparator)
-	        else 
+	        } else {
 	          TestVec(testDir.toString + "/" + output,
-	              testDir.toString + "/" + ref, TestComparator.txtComparator)	        
+	              testDir.toString + "/" + ref, TestComparator.txtComparator)
+	        }
 	      }
-	      TestCase(f.toPath().toString, testVecs.toList)
+	      TestCase(f.toPath().toString, args, testVecs.toList)
 	  }
 	  
 	  for (tc <- testCases) {
-	   
             try {
-	       co.uproot.abandon.CLIMain.runAppThrows(Array("-c", tc.conf))
+	       co.uproot.abandon.CLIMain.runAppThrows(Array("-c", tc.conf) ++ tc.args)
 	    } catch {
                case _: Throwable => assert(false)
             }

--- a/cli/src/test/scala/co/uproot/abandon/TestComparator.scala
+++ b/cli/src/test/scala/co/uproot/abandon/TestComparator.scala
@@ -30,5 +30,5 @@ object TestComparator extends FlatSpec  {
 
 case class TestVec(output: String, reference: String, comparator: (String, String) => Boolean)
 
-case class TestCase(conf: String, testVec: List[TestVec])
+case class TestCase(conf: String, args: Array[String], testVec: List[TestVec])
 	  

--- a/testCases/README.md
+++ b/testCases/README.md
@@ -22,6 +22,20 @@ Inside a test directory, there must be:
  - reference output files, filenames MUST follow convention: 
    (e.g. bal01.ref.balance.xml and bal01.ref.journal.xml)
 
+ - Optionally use extra command line arguments for current test case.
+   These arguments are listed on "args"-file (e.g. bal01.args),
+   one argument per line, and this file MUST NOT contain
+   "-c", "conf-file" args.
+
+   For example filter-arguments:
+   ```
+   --filter
+   begin=2013-01-01
+   end=2013-12-31
+   ```
+   Each argument line is trimmed, so whitespace is removed
+   from begining and at end.
+
 Abandon configuration MUST output one file per reference file
 in following filename format:
    e.g. bal01.conf -> bal01.ref.balance.xml -> out.bal01.balance.xml


### PR DESCRIPTION
This adds command line support to test runner, and makes sure that old, stale files won't be used as output.  This is testing-only change.

Please use commit (d9aaeb29) for review, because that is the actual commit with changes. Last commit is indentation fix (tab -> spaces), with no functional changes, but github can't show that (e.g. "diff -w")?
