### PR TITLE
report-grouping-refactor: Refactor reporting day grouping code.

### DIFF
--- a/base/src/main/scala/co/uproot/abandon/Ast.scala
+++ b/base/src/main/scala/co/uproot/abandon/Ast.scala
@@ -38,8 +38,31 @@ case class Date(year: Int, month: Int, day: Int) {
     f"$year%4d / $month%d / $day%d"
   }
 
+  /**
+    * @return ISO 8601 extended day (YYYY-MM-DD)
+    */
   def formatISO8601Ext = {
     f"$year%4d-$month%02d-$day%02d"
+  }
+
+  /**
+    * @return ISO-8601 week without day (2010-01-01 => 2009-W53)
+    */
+  def formatISO8601Week = {
+    val frmtISOWeek = java.time.format.DateTimeFormatter.ISO_WEEK_DATE
+    val jDate = java.time.LocalDate.of(year, month, day)
+
+    jDate.format(frmtISOWeek).substring(0,8)
+  }
+
+  /**
+    * @return ISO-8601 week with week day (2010-01-01 => 2009-W53-5)
+    */
+  def formatISO8601WeekDay = {
+    val frmtISOWeek = java.time.format.DateTimeFormatter.ISO_WEEK_DATE
+    val jDate = java.time.LocalDate.of(year, month, day)
+
+    jDate.format(frmtISOWeek)
   }
 
   def formatCompactYYYYMMDD = {
@@ -50,12 +73,25 @@ case class Date(year: Int, month: Int, day: Int) {
     f"$year%4d ${Helper.getShortMonth(month)} $day%d"
   }
 
+  /**
+    * @return date as int with day resolution
+    */
   def toInt = {
     year * Date.yearMultiplier + month * Date.monthMultiplier + day
   }
 
+  /**
+    * @return date as int with month resolution
+    */
   def toIntYYYYMM = {
     year * Date.yearMultiplier + month * Date.monthMultiplier
+  }
+
+  /**
+    * @return date as int with year resolution
+    */
+  def toIntYYYY = {
+    year * Date.yearMultiplier
   }
 
   def formatCompact = {
@@ -64,6 +100,10 @@ case class Date(year: Int, month: Int, day: Int) {
 
   def hasDayResolution = {
     day != 0
+  }
+
+  def hasMonthResolution = {
+    month != 0
   }
 }
 

--- a/base/src/main/scala/co/uproot/abandon/Ast.scala
+++ b/base/src/main/scala/co/uproot/abandon/Ast.scala
@@ -54,8 +54,16 @@ case class Date(year: Int, month: Int, day: Int) {
     year * Date.yearMultiplier + month * Date.monthMultiplier + day
   }
 
+  def toIntYYYYMM = {
+    year * Date.yearMultiplier + month * Date.monthMultiplier
+  }
+
   def formatCompact = {
     s"$year,$month,$day"
+  }
+
+  def hasDayResolution = {
+    day != 0
   }
 }
 

--- a/base/src/test/scala/co/uproot/abandon/AstTest.scala
+++ b/base/src/test/scala/co/uproot/abandon/AstTest.scala
@@ -16,11 +16,17 @@ class AstTest extends FlatSpec with Matchers {
     testDate.toIntYYYYMM should be(20160100)
   }
 
+  "Date" should "convert to int with year resolution" in {
+    val testDate = Date(2016, 1, 2)
+    testDate.toIntYYYY should be(20160000)
+  }
+
   it should "be possible to convert from int" in {
     val testDate = Date.fromInt(20160102)
     testDate.year should be(2016)
     testDate.month should be(1)
     testDate.day should be (2)
+    testDate.hasMonthResolution should be (true)
     testDate.hasDayResolution should be (true)
   }
 
@@ -29,9 +35,19 @@ class AstTest extends FlatSpec with Matchers {
     testDate.year should be(2016)
     testDate.month should be(1)
     testDate.day should be (0)
+    testDate.hasMonthResolution should be (true)
     testDate.hasDayResolution should be (false)
   }
-  
+
+  it should "be possible to convert from int with year resolution" in {
+    val testDate = Date.fromInt(20160000)
+    testDate.year should be(2016)
+    testDate.month should be(0)
+    testDate.day should be (0)
+    testDate.hasDayResolution should be (false)
+    testDate.hasMonthResolution should be (false)
+  }
+
   it should "compare correctly" in {
     import scala.util.Sorting
 
@@ -148,4 +164,25 @@ class AstTest extends FlatSpec with Matchers {
         case (date, refDate) => date.formatYYYYMMMDD == refDate
       }) should be(true)
   }
+
+  it should "format ISO 8601 weeks correctly" in {
+    val dates = List(
+      (Date(2005, 1, 2),   "2004-W53", "2004-W53-7"),
+      (Date(2005, 12, 31), "2005-W52", "2005-W52-6"),
+      (Date(2007, 1, 1),   "2007-W01", "2007-W01-1"),
+      (Date(2008, 1, 1),   "2008-W01", "2008-W01-2"),
+      (Date(2008, 12, 29), "2009-W01", "2009-W01-1"),
+      (Date(2008, 12, 31), "2009-W01", "2009-W01-3"),
+      (Date(2010, 1, 1),   "2009-W53", "2009-W53-5"),
+      (Date(2010, 1, 3),   "2009-W53", "2009-W53-7"),
+      (Date(2010, 1, 4),   "2010-W01", "2010-W01-1"))
+
+    dates.forall({
+      case (date, refWeek, refWeekDay) => {
+        date.formatISO8601Week == refWeek &&
+        date.formatISO8601WeekDay == refWeekDay
+      }
+    }) should be(true)
+  }
+
 }

--- a/base/src/test/scala/co/uproot/abandon/AstTest.scala
+++ b/base/src/test/scala/co/uproot/abandon/AstTest.scala
@@ -11,11 +11,25 @@ class AstTest extends FlatSpec with Matchers {
     testDate.toInt should be(20160102)
   }
 
+  "Date" should "convert to int with month resolution" in {
+    val testDate = Date(2016, 1, 2)
+    testDate.toIntYYYYMM should be(20160100)
+  }
+
   it should "be possible to convert from int" in {
     val testDate = Date.fromInt(20160102)
     testDate.year should be(2016)
     testDate.month should be(1)
     testDate.day should be (2)
+    testDate.hasDayResolution should be (true)
+  }
+
+  it should "be possible to convert from int with month resolution" in {
+    val testDate = Date.fromInt(20160100)
+    testDate.year should be(2016)
+    testDate.month should be(1)
+    testDate.day should be (0)
+    testDate.hasDayResolution should be (false)
   }
   
   it should "compare correctly" in {


### PR DESCRIPTION
This refactors reporting day grouping code and adds few new functions to do grouping based on years, months or dates. Also this adds functions to do grouping based on ISO 8601 weeks. All new functions have unit tests. The last failure for (fb8abde) is Travis error: 

`The command "sudo -E apt-get -yq --no-install-suggests --no-install-recommends --force-yes install oracle-java8-installer" failed and exited with 100 during .`

This removes special handling and uses of int-dates (e.g. non-Ast defined multipliers for year), and makes it easier to implement different grouping code in future (e.g. groupBy(date.toInt)).