### PR TITLE
Refactor version info

### DIFF
--- a/base/src/main/scala/co/uproot/abandon/Report.scala
+++ b/base/src/main/scala/co/uproot/abandon/Report.scala
@@ -270,10 +270,9 @@ object Reports {
         </balance>
       </abandon>
 
-    if (exportSettings.withoutVersion) {
-      balance
-    } else {
-      addAttribute(balance, "version", BuildInfo.version)
+    exportSettings.version match {
+      case Some(version) => addAttribute(balance, "version", version.id)
+      case None => balance
     }
   }
 
@@ -310,10 +309,9 @@ object Reports {
         </journal>
       </abandon>
 
-    if (exportSettings.withoutVersion) {
-      journal
-    } else {
-      addAttribute(journal, "version", BuildInfo.version)
+    exportSettings.version match {
+      case Some(version) => addAttribute(journal, "version", version.id)
+      case None => journal
     }
   }
 

--- a/base/src/test/scala/co/uproot/abandon/ComplexProcessTest.scala
+++ b/base/src/test/scala/co/uproot/abandon/ComplexProcessTest.scala
@@ -18,9 +18,9 @@ class ComplexProcessTest extends FlatSpec with Matchers with Inside {
 		val (parseError, scope, processedFiles) = Processor.parseAll(Seq("tests/small.ledger"), quiet)
 	  assert(!parseError)
 
-	  val xmlBalSettings = XmlExportSettings(BalanceType, None, Seq("not-used.xml"), true)
-	  val xmlTxnSettings = XmlExportSettings(JournalType, None, Seq("not-used.xml"), true)
-	  val settings = Settings(Nil, Nil, Nil, Nil, ReportOptions(Nil), Seq(xmlBalSettings), None, quiet, None)
+	  val xmlBalSettings = XmlExportSettings(BalanceType, None, Seq("not-used.xml"), None)
+	  val xmlTxnSettings = XmlExportSettings(JournalType, None, Seq("not-used.xml"), None)
+	  val settings = Settings(Nil, Nil, Nil, Nil, ReportOptions(Nil), Seq(xmlBalSettings), None, quiet, None, None)
 
 	  val appState = Processor.process(scope,settings.accounts, None)
 	  //TODO: Processor.checkConstaints(appState, settings.eodConstraints)

--- a/base/src/test/scala/co/uproot/abandon/ProcessorTest.scala
+++ b/base/src/test/scala/co/uproot/abandon/ProcessorTest.scala
@@ -24,7 +24,7 @@ class ProcessorTest extends FlatSpec with Matchers with Inside {
         val appState = Processor.process(scope, Nil, None)
         val balSettings = LedgerExportSettings(None, Seq("balSheet12.txt"), false, Nil)
 
-        val settings = Settings(Nil, Nil, Nil, Nil, ReportOptions(Nil), Seq(balSettings), None, false, None)
+        val settings = Settings(Nil, Nil, Nil, Nil, ReportOptions(Nil), Seq(balSettings), None, false, None, None)
 
         val ledgerRep = Reports.ledgerExport(appState, settings, balSettings)
         inside(ledgerRep) {
@@ -54,7 +54,7 @@ class ProcessorTest extends FlatSpec with Matchers with Inside {
         val appState = Processor.process(scope, Nil, None)
 
         val balSettings = LedgerExportSettings(None, Seq("balSheet12.txt"), false, Nil)
-        val settings = Settings(Nil, Nil, Nil, Nil, ReportOptions(Nil), Seq(balSettings), None, false, None)
+        val settings = Settings(Nil, Nil, Nil, Nil, ReportOptions(Nil), Seq(balSettings), None, false, None, None)
 
         val ledgerRep = Reports.ledgerExport(appState, settings, balSettings)
         inside(ledgerRep) {
@@ -84,7 +84,7 @@ class ProcessorTest extends FlatSpec with Matchers with Inside {
         val appState = Processor.process(scope, Nil, None)
 
         val balSettings = LedgerExportSettings(None, Seq("balSheet12.txt"), true, Nil)
-        val settings = Settings(Nil, Nil, Nil, Nil, ReportOptions(Nil), Seq(balSettings), None, false, None)
+        val settings = Settings(Nil, Nil, Nil, Nil, ReportOptions(Nil), Seq(balSettings), None, false, None, None)
 
         val ledgerRep = Reports.ledgerExport(appState, settings, balSettings)
         inside(ledgerRep) {
@@ -112,7 +112,7 @@ class ProcessorTest extends FlatSpec with Matchers with Inside {
         val appState = Processor.process(scope, Nil, None)
 
         val balSettings = LedgerExportSettings(None, Seq("balSheet12.txt"), false, Nil)
-        val settings = Settings(Nil, Nil, Nil, Nil, ReportOptions(Nil), Seq(balSettings), None, false, None)
+        val settings = Settings(Nil, Nil, Nil, Nil, ReportOptions(Nil), Seq(balSettings), None, false, None, None)
 
         val ledgerRep = Reports.ledgerExport(appState, settings, balSettings)
         ledgerRep should be (Nil)
@@ -136,7 +136,7 @@ class ProcessorTest extends FlatSpec with Matchers with Inside {
         val closure = Seq(ClosureExportSettings(source, destination))
 
         val balSettings = LedgerExportSettings(None, Seq("balSheet12.txt"), false, closure)
-        val settings = Settings(Nil, Nil, Nil, Nil, ReportOptions(Nil), Seq(balSettings), None, false, None)
+        val settings = Settings(Nil, Nil, Nil, Nil, ReportOptions(Nil), Seq(balSettings), None, false, None, None)
 
         val ledgerRep = Reports.ledgerExport(appState, settings, balSettings)
         inside(ledgerRep) {
@@ -190,7 +190,7 @@ class ProcessorTest extends FlatSpec with Matchers with Inside {
         val closure = closure1 ++ closure2
         val balSettings = LedgerExportSettings(None, Seq("balSheet12.txt"), false, closure)
 
-        val settings = Settings(Nil, Nil, Nil, Nil, ReportOptions(Nil), Seq(balSettings), None, false, None)
+        val settings = Settings(Nil, Nil, Nil, Nil, ReportOptions(Nil), Seq(balSettings), None, false, None, None)
 
         val ledgerRep = intercept[InputError] {
           Reports.ledgerExport(appState, settings, balSettings)
@@ -215,7 +215,7 @@ class ProcessorTest extends FlatSpec with Matchers with Inside {
         val closure = Seq(ClosureExportSettings(source, destination))
 
         val balSettings = LedgerExportSettings(None, Seq("balSheet12.txt"), false, closure)
-        val settings = Settings(Nil, Nil, Nil, Nil, ReportOptions(Nil), Seq(balSettings), None, false, None)
+        val settings = Settings(Nil, Nil, Nil, Nil, ReportOptions(Nil), Seq(balSettings), None, false, None, None)
 
         val ledgerRep = intercept[MissingDestinationError] {
           Reports.ledgerExport(appState, settings, balSettings)
@@ -240,7 +240,7 @@ class ProcessorTest extends FlatSpec with Matchers with Inside {
         val closure = Seq(ClosureExportSettings(source, destination))
 
         val balSettings = LedgerExportSettings(None, Seq("balSheet12.txt"), false, closure)
-        val settings = Settings(Nil, Nil, Nil, Nil, ReportOptions(Nil), Seq(balSettings), None, false, None)
+        val settings = Settings(Nil, Nil, Nil, Nil, ReportOptions(Nil), Seq(balSettings), None, false, None, None)
 
         val ledgerRep = intercept[SourceDestinationClashError] {
           Reports.ledgerExport(appState, settings, balSettings)
@@ -265,7 +265,7 @@ class ProcessorTest extends FlatSpec with Matchers with Inside {
         val accounts = Seq(AccountSettings(name, Some(alias)))
 
         val balSettings = LedgerExportSettings(None, Seq("balSheet12.txt"), false, Nil)
-        val settings = Settings(Nil, Nil, accounts, Nil, ReportOptions(Nil), Seq(balSettings), None, false, None)
+        val settings = Settings(Nil, Nil, accounts, Nil, ReportOptions(Nil), Seq(balSettings), None, false, None, None)
 
         val appState = Processor.process(scope, settings.accounts, None)
 

--- a/build.sbt
+++ b/build.sbt
@@ -40,30 +40,42 @@ lazy val abandon = (project in file(".")).
   )
 
 lazy val base = (project in file("base")).
-  settings(commonSettings: _*).
   enablePlugins(BuildInfoPlugin).
+  settings(commonSettings: _*).
   settings(
     name := "abandon-base",
     fork in run := true,
     buildInfoKeys := Seq[BuildInfoKey](name, version, scalaVersion, sbtVersion),
-    buildInfoPackage := "co.uproot.abandon"
+    buildInfoOptions += BuildInfoOption.BuildTime,
+    buildInfoPackage := "co.uproot.abandon",
+    buildInfoObject := "BaseBuildInfo"
   )
 
 
 lazy val cli = (project in file("cli")).
+  enablePlugins(BuildInfoPlugin).
   dependsOn(base).
   settings(commonSettings: _*).
   settings(
     name := "abandon-cli",
-    fork in run := true
+    fork in run := true,
+    buildInfoKeys := Seq[BuildInfoKey](name, version, scalaVersion, sbtVersion),
+    buildInfoOptions += BuildInfoOption.BuildTime,
+    buildInfoPackage := "co.uproot.abandon",
+    buildInfoObject := "CliBuildInfo"
   )
 
 lazy val gui = (project in file("gui")).
+  enablePlugins(BuildInfoPlugin).
   dependsOn(base).
   settings(commonSettings: _*).
   settings(
     name := "abandon-gui",
-    fork in run := true
+    fork in run := true,
+    buildInfoKeys := Seq[BuildInfoKey](name, version, scalaVersion, sbtVersion),
+    buildInfoOptions += BuildInfoOption.BuildTime,
+    buildInfoPackage := "co.uproot.abandon",
+    buildInfoObject := "GuiBuildInfo"
   )
 
 

--- a/cli/src/main/scala/co/uproot/abandon/App.scala
+++ b/cli/src/main/scala/co/uproot/abandon/App.scala
@@ -1,8 +1,8 @@
 package co.uproot.abandon
 
-import org.rogach.scallop.{ ScallopConf, stringListConverter }
-import Helper.{ Zero, filterByType, maxElseZero }
 import java.io.FileWriter
+
+import co.uproot.abandon.Helper.maxElseZero
 
 final class ReportWriter(settings: Settings, outFiles: Seq[String]) {
   val writesToScreen = outFiles.contains("-") || outFiles.isEmpty
@@ -149,9 +149,13 @@ object CLIMain  {
     }
     reportWriter.endCodeBlock()
   }
+  def buildId: String = {
+    "Base: " + BaseBuildInfo.version + " [" + BaseBuildInfo.builtAtString + "];" +
+      "CLI: " + CliBuildInfo.version + " [" + CliBuildInfo.builtAtString + "];"
+  }
 
   def runAppThrows(args: Array[String]) {
-    val settingsResult = SettingsHelper.getCompleteSettings(args)
+    val settingsResult = SettingsHelper.getCompleteSettings(args, buildId)
     settingsResult match {
       case Left(errorMsg) => printErrAndExit(errorMsg)
       case Right(settings) =>

--- a/gui/src/main/scala/co/uproot/abandon/UI.scala
+++ b/gui/src/main/scala/co/uproot/abandon/UI.scala
@@ -1,17 +1,16 @@
 package co.uproot.abandon
 
-import scalafx.Includes._
 import javafx.event.EventHandler
 import javafx.stage.WindowEvent
-import scalafx.application.JFXApp
+
+import scala.collection.JavaConverters._
+import scalafx.Includes._
 import scalafx.application.JFXApp.PrimaryStage
-import scalafx.geometry.Insets
-import scalafx.scene.{ Node, Scene }
-import scalafx.scene.control.{ Label, Tab, TabPane, TreeItem }
-import scalafx.scene.layout.{ BorderPane, HBox, Priority }
-import scalafx.application.Platform
-import collection.JavaConverters._
-import scalafx.geometry.Pos
+import scalafx.application.{JFXApp, Platform}
+import scalafx.geometry.{Insets, Pos}
+import scalafx.scene.control.{Label, Tab, TabPane}
+import scalafx.scene.layout.{BorderPane, HBox}
+import scalafx.scene.{Node, Scene}
 
 trait UIReport {
   protected val styleClassName = "report"
@@ -149,9 +148,13 @@ object AbandonUI extends JFXApp {
     }
     processedFiles
   }
+  def buildId: String = {
+    "Base: " + BaseBuildInfo.version + " [" + BaseBuildInfo.builtAtString + "];" +
+      "GUI: " +  GuiBuildInfo.version + " [" + GuiBuildInfo.builtAtString + "];"
+  }
 
   try {
-    val settingsResult = SettingsHelper.getCompleteSettings(parameters.raw)
+    val settingsResult = SettingsHelper.getCompleteSettings(parameters.raw, buildId)
     settingsResult match {
       case Left(errorMsg) => handleError("Error: " + errorMsg)
       case Right(settings) =>


### PR DESCRIPTION
Hello, this PR is about version info refactoring, so that it will be more usable from perspective  of package (base) or from application perspective (cli, gui). This also change the version info boolean to case class, which have two benefits: 
 - Passing argument around is more typesafe
 - Caller can deside which information to include into version info

It is also good to have own version stamp for base-package and app, because with own base package it could be possible to use published base-package to build app (which will have own buildInfo-data).

This also cleaned up and organized imports with modified files.

Next step is cli-argument (`--version`) to ask version info from CLI/GUI app.

Original commit message:
 - Provide each component (base,cli,gui) own version info.
 - Add buildtime to BuildInfo object, so it can be used, if so wished.
 - Move initial version info injection up to the main app (cli or gui).
 - Use own case class for passing build/version info around.