### PR TITLE
Add support for -h arg

### DIFF
--- a/base/src/main/scala/co/uproot/abandon/Config.scala
+++ b/base/src/main/scala/co/uproot/abandon/Config.scala
@@ -30,6 +30,7 @@ class AbandonCLIConf(arguments: Seq[String]) extends ScallopConf(arguments) {
   val unversioned = opt[Boolean]("unversioned", short = 'X')
   val quiet = opt[Boolean]("quiet", short = 'q')
   val version = opt[Boolean]("version", noshort = true)
+  val help = opt[Boolean]("help", short = 'h')
 }
 
 object SettingsHelper {

--- a/base/src/main/scala/co/uproot/abandon/Config.scala
+++ b/base/src/main/scala/co/uproot/abandon/Config.scala
@@ -4,7 +4,7 @@ import java.time.format.DateTimeParseException
 
 import com.typesafe.config.{Config, ConfigException, ConfigFactory}
 import org.rogach.scallop.ScallopConf
-import org.rogach.scallop.exceptions.ScallopException
+import org.rogach.scallop.exceptions.{Help, ScallopException, Version}
 
 import scala.collection.JavaConverters._
 
@@ -18,7 +18,19 @@ class AbandonCLIConf(arguments: Seq[String]) extends ScallopConf(arguments) {
   override def onError(e: Throwable): Unit = e match {
     case ex: ScallopException => {
       printHelp
-      throw ex
+      throw e
+    }
+    case Help("") => {
+      builder.printHelp
+      throw e
+    }
+    case Help(subname) => {
+      builder.findSubbuilder(subname).get.printHelp
+      throw e
+    }
+    case Version => {
+      builder.vers.foreach(println)
+      throw e
     }
     case other => super.onError(other)
   }

--- a/cli/src/main/scala/co/uproot/abandon/App.scala
+++ b/cli/src/main/scala/co/uproot/abandon/App.scala
@@ -4,7 +4,7 @@ import java.io.FileWriter
 import java.nio.file.{Files, Paths}
 
 import co.uproot.abandon.Helper.maxElseZero
-import org.rogach.scallop.exceptions.ScallopException
+import org.rogach.scallop.exceptions.{Help, ScallopException, Version}
 
 final class ReportWriter(settings: Settings, outFiles: Seq[String]) {
   val writesToScreen = outFiles.contains("-") || outFiles.isEmpty
@@ -255,12 +255,14 @@ object CLIApp {
     */
   def run(args: Array[String]): Unit = {
     val cliConf = new AbandonCLIConf(args)
-    cliConf.verify()
+    cliConf.version("Version: " + CliBuildInfo.version + " [" + CliBuildInfo.builtAtString + "]")
 
-    if (cliConf.version.supplied) {
-      println("Version: " + CliBuildInfo.version + " [" + CliBuildInfo.builtAtString + "]")
-    } else {
+    try {
+      cliConf.verify()
       runApp(cliConf)
+    } catch {
+      case Help(_) =>
+      case Version =>
     }
   }
 

--- a/cli/src/test/scala/co/uproot/abandon/CLIMainTest.scala
+++ b/cli/src/test/scala/co/uproot/abandon/CLIMainTest.scala
@@ -8,18 +8,14 @@ class CLIMainTest extends FlatSpec with Matchers {
   it should "handle version" in {
     co.uproot.abandon.CLIApp.run(Array("--version"))
   }
-  it should "handle -h by throwing a Help exception" in {
-    an [org.rogach.scallop.exceptions.Help] should be thrownBy {
-      co.uproot.abandon.CLIApp.run(Array("-h"))
-    }
+  it should "handle h" in {
+    co.uproot.abandon.CLIApp.run(Array("-h"))
   }
-  it should "handle --help by throwing a Help exception" in {
-    an [org.rogach.scallop.exceptions.Help] should be thrownBy {
-      co.uproot.abandon.CLIApp.run(Array("--help"))
-    }
+  it should "handle help" in {
+    co.uproot.abandon.CLIApp.run(Array("--help"))
   }
   it should "handle an unknown option by throwing an UnknownOption exception" in {
-    an [org.rogach.scallop.exceptions.UnknownOption] should be thrownBy {
+    an[org.rogach.scallop.exceptions.UnknownOption] should be thrownBy {
       co.uproot.abandon.CLIApp.run(Array("--unknown"))
     }
   }

--- a/cli/src/test/scala/co/uproot/abandon/CLIMainTest.scala
+++ b/cli/src/test/scala/co/uproot/abandon/CLIMainTest.scala
@@ -1,11 +1,16 @@
 package co.uproot.abandon
 
-import org.scalatest.FlatSpec
+import org.scalatest.{FlatSpec, Matchers}
 
-class CLIMainTest extends FlatSpec {
+class CLIMainTest extends FlatSpec with Matchers {
 
   behavior of "Abandon CLI with no-op args"
   it should "handle version" in {
     co.uproot.abandon.CLIApp.run(Array("--version"))
+  }
+  it should "handle -h by throwing the Help exception" in {
+    an [org.rogach.scallop.exceptions.Help] should be thrownBy {
+      co.uproot.abandon.CLIApp.run(Array("-h"))
+    }
   }
 }

--- a/cli/src/test/scala/co/uproot/abandon/CLIMainTest.scala
+++ b/cli/src/test/scala/co/uproot/abandon/CLIMainTest.scala
@@ -8,9 +8,19 @@ class CLIMainTest extends FlatSpec with Matchers {
   it should "handle version" in {
     co.uproot.abandon.CLIApp.run(Array("--version"))
   }
-  it should "handle -h by throwing the Help exception" in {
+  it should "handle -h by throwing a Help exception" in {
     an [org.rogach.scallop.exceptions.Help] should be thrownBy {
       co.uproot.abandon.CLIApp.run(Array("-h"))
+    }
+  }
+  it should "handle --help by throwing a Help exception" in {
+    an [org.rogach.scallop.exceptions.Help] should be thrownBy {
+      co.uproot.abandon.CLIApp.run(Array("--help"))
+    }
+  }
+  it should "handle an unknown option by throwing an UnknownOption exception" in {
+    an [org.rogach.scallop.exceptions.UnknownOption] should be thrownBy {
+      co.uproot.abandon.CLIApp.run(Array("--unknown"))
     }
   }
 }


### PR DESCRIPTION
Offering -h option by adding an option with name "help" and short name "h" and letting Scallop handle the printing of the help text