### PR TITLE
Protect input files from being over-written #116

### DIFF
--- a/base/src/main/scala/co/uproot/abandon/Config.scala
+++ b/base/src/main/scala/co/uproot/abandon/Config.scala
@@ -144,6 +144,25 @@ object SettingsHelper {
       }
     }
 
+    def ensureInputProtection(inputs: List[String], reports: List[ReportSettings], exports: List[ExportSettings]): Unit = {
+      val inputFiles: Seq[java.io.File] = inputs.map(new java.io.File(_))
+      val repOutFiles: Seq[String] = reports.flatMap(_.outFiles)
+      val expOutFiles: Seq[String] = exports.flatMap(_.outFiles)
+
+      val overwritten = for {
+        inputFile <- inputFiles
+        repOutFile <- repOutFiles
+        expOutFile <- expOutFiles
+        if inputFile.exists() && (inputFile == new java.io.File(inputFile.getParent, repOutFile) || inputFile == new java.io.File(inputFile.getParent, expOutFile))
+      } yield inputFile
+
+      val result = overwritten.toSet
+      if (result.nonEmpty) {
+        val fileNames = result.mkString(", ")
+        throw new ConfigException.Generic(s"Overwriting input files: $fileNames")
+      }
+    }
+
     val file = new java.io.File(configFileName)
     if (file.exists) {
       try {
@@ -157,6 +176,8 @@ object SettingsHelper {
         val accountConfigs = config.optConfigList("accounts").getOrElse(Nil)
         val accounts = accountConfigs.map(makeAccountSettings)
         val eodConstraints = config.optConfigList("eodConstraints").getOrElse(Nil).map(makeEodConstraints(_))
+
+        ensureInputProtection(inputs.toList, reports.toList, exports.toList)
 
        /*
         * filters, precedence

--- a/base/src/main/scala/co/uproot/abandon/Process.scala
+++ b/base/src/main/scala/co/uproot/abandon/Process.scala
@@ -5,6 +5,8 @@ import scala.util.parsing.input.PagedSeqReader
 import scala.collection.immutable.PagedSeq
 import java.io.FileNotFoundException
 
+import java.nio.file.{Path, Paths}
+
 case class AppState(accState: AccountState)
 
 class PostGroup(
@@ -199,6 +201,10 @@ object Processor {
 
   def mkAbsolutePath(path: String) = {
     (new java.io.File(path)).getCanonicalPath
+  }
+
+  def mkPath(path: String): Path = {
+    Paths.get(path).normalize()
   }
 
   def process(scope: Scope, accountSettings: Seq[AccountSettings], txnFilters: Option[TxnFilterStack]) = {

--- a/cli/src/main/scala/co/uproot/abandon/App.scala
+++ b/cli/src/main/scala/co/uproot/abandon/App.scala
@@ -7,8 +7,8 @@ import co.uproot.abandon.Helper.maxElseZero
 import org.rogach.scallop.exceptions.{Help, ScallopException, Version}
 
 final class ReportWriter(settings: Settings, outFiles: Seq[String]) {
-  val writesToScreen = outFiles.contains("-") || outFiles.isEmpty
-  val filePaths = outFiles.filterNot(_ equals "-").map(settings.getConfigRelativePath(_))
+  val writesToScreen = settings.writesToScreen(outFiles)
+  val filePaths = settings.getConfigRelativePaths(outFiles)
   val fileWriters = filePaths.map(pathStr =>  {
       val path = Paths.get(pathStr).normalize
       val parentPath = path.getParent

--- a/cli/src/main/scala/co/uproot/abandon/App.scala
+++ b/cli/src/main/scala/co/uproot/abandon/App.scala
@@ -183,7 +183,7 @@ object CLIApp {
       case Right(settings) =>
         val (parseError, astEntries, processedFiles) = Processor.parseAll(settings.inputs, settings.quiet)
         if (!parseError) {
-          SettingsHelper.ensureInputProtection(processedFiles, settings.reports.toSet, settings.exports.toSet)
+          SettingsHelper.ensureInputProtection(processedFiles, settings)
           val txnFilters = None
           val appState = Processor.process(astEntries,settings.accounts, settings.txnFilters)
           Processor.checkConstaints(appState, settings.constraints)

--- a/cli/src/main/scala/co/uproot/abandon/App.scala
+++ b/cli/src/main/scala/co/uproot/abandon/App.scala
@@ -183,6 +183,7 @@ object CLIApp {
       case Right(settings) =>
         val (parseError, astEntries, processedFiles) = Processor.parseAll(settings.inputs, settings.quiet)
         if (!parseError) {
+          SettingsHelper.ensureInputProtection(processedFiles, settings.reports.toSet, settings.exports.toSet)
           val txnFilters = None
           val appState = Processor.process(astEntries,settings.accounts, settings.txnFilters)
           Processor.checkConstaints(appState, settings.constraints)

--- a/tests/errors/SettingsError/output/o01-include.ledger
+++ b/tests/errors/SettingsError/output/o01-include.ledger
@@ -1,0 +1,5 @@
+; March 2012
+2012/3/1  OpeningBalance
+  Capital:Owner                                  6,000
+  Assets:Current:BankAccount                    -5,000
+  Assets:Fixed:Computer                         -1,000

--- a/tests/errors/SettingsError/output/o01.conf
+++ b/tests/errors/SettingsError/output/o01.conf
@@ -1,0 +1,26 @@
+inputs += o01.ledger
+
+reportOptions = {
+  isRight = [Liability, Capital, Income]
+}
+
+// overwriting o01.ledger should result in an error
+reports += {
+  title = "Balance Sheet"
+  type = balance
+  outFiles = [o01.ledger, "-"]
+  accountMatch = ["^Assets.*", "^Liability.*", "^Capital.*"]
+}
+
+reports += {
+  title = "Profit and Loss" 
+  type = balance
+  accountMatch = ["^Income.*", "^Expenses.*"]
+}
+
+// overwriting o01-include.ledger should result in an error
+exports += {
+  type = balance
+  format = xml
+  outFiles = [o01-include.ledger]
+}

--- a/tests/errors/SettingsError/output/o01.exec
+++ b/tests/errors/SettingsError/output/o01.exec
@@ -1,0 +1,2 @@
+# format: exec
+exec:

--- a/tests/errors/SettingsError/output/o01.ledger
+++ b/tests/errors/SettingsError/output/o01.ledger
@@ -1,0 +1,34 @@
+include o01-include.ledger
+
+; Oct 2012
+2012/Oct/5
+  Expenses:Bank_Charges                               -200
+  Assets:Current:BankAccount
+
+; Jan 2013
+2013/Jan/15  (89000) Alice Enterprises
+  ; For Office Stationary
+  Expenses:Consumables                                -400
+  Assets:Current:BankAccount
+
+
+2013/1/29 (89001) Bob Traders
+  ; For 14" monitor
+  Assets:Fixed:Computer                            -2000
+  Assets:Current:BankAccount
+
+2013/Feb/14  Persistent Helpers
+  ; Loan
+  Liability:Loan              5,000
+  Assets:Current:BankAccount
+
+2013/Feb/16  (80005) Deepika
+  ; January Salary
+  Expenses:Salaries                                 -2,000
+  Assets:Current:BankAccount
+
+2013/1/4
+  ; Invoice a
+  Assets:Current:Sundry_Debtors:Vikings         -25,000
+  Income:Receipts               
+

--- a/tests/errors/SettingsError/output/o02-include.ledger
+++ b/tests/errors/SettingsError/output/o02-include.ledger
@@ -1,0 +1,5 @@
+; March 2012
+2012/3/1  OpeningBalance
+  Capital:Owner                                  6,000
+  Assets:Current:BankAccount                    -5,000
+  Assets:Fixed:Computer                         -1,000

--- a/tests/errors/SettingsError/output/o02.conf
+++ b/tests/errors/SettingsError/output/o02.conf
@@ -1,14 +1,13 @@
-inputs += o01.ledger
+inputs += o02.ledger
 
 reportOptions = {
   isRight = [Liability, Capital, Income]
 }
 
-// overwriting o01-include.ledger should result in an error
 reports += {
   title = "Balance Sheet"
   type = balance
-  outFiles = [o01-include.ledger, "-"]
+  outFiles = [balSheet.txt, "-"]
   accountMatch = ["^Assets.*", "^Liability.*", "^Capital.*"]
 }
 
@@ -16,4 +15,11 @@ reports += {
   title = "Profit and Loss" 
   type = balance
   accountMatch = ["^Income.*", "^Expenses.*"]
+}
+
+// overwriting o02-include.ledger should result in an error
+exports += {
+  type = balance
+  format = xml
+  outFiles = [o02-include.ledger]
 }

--- a/tests/errors/SettingsError/output/o02.exec
+++ b/tests/errors/SettingsError/output/o02.exec
@@ -1,0 +1,2 @@
+# format: exec
+exec:

--- a/tests/errors/SettingsError/output/o02.ledger
+++ b/tests/errors/SettingsError/output/o02.ledger
@@ -1,0 +1,34 @@
+include o02-include.ledger
+
+; Oct 2012
+2012/Oct/5
+  Expenses:Bank_Charges                               -200
+  Assets:Current:BankAccount
+
+; Jan 2013
+2013/Jan/15  (89000) Alice Enterprises
+  ; For Office Stationary
+  Expenses:Consumables                                -400
+  Assets:Current:BankAccount
+
+
+2013/1/29 (89001) Bob Traders
+  ; For 14" monitor
+  Assets:Fixed:Computer                            -2000
+  Assets:Current:BankAccount
+
+2013/Feb/14  Persistent Helpers
+  ; Loan
+  Liability:Loan              5,000
+  Assets:Current:BankAccount
+
+2013/Feb/16  (80005) Deepika
+  ; January Salary
+  Expenses:Salaries                                 -2,000
+  Assets:Current:BankAccount
+
+2013/1/4
+  ; Invoice a
+  Assets:Current:Sundry_Debtors:Vikings         -25,000
+  Income:Receipts               
+


### PR DESCRIPTION
Hi @hrj , that's the fix for the issue #116. I'm checking for potential overwriting of input files right after the program has parsed all of them, e.g. also those that are included in other input files via the "include" instruction. Please let me know if that's what you had in mind.

Edit:
Closes #116 