### PR TITLE
add workaround for jboss interceptor library sha mismatch issue

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,4 @@
+resolvers += "JBoss" at "https://repository.jboss.org/"
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.3")
 
 // addSbtPlugin("com.typesafe.sbt" % "sbt-proguard" % "0.2.2")


### PR DESCRIPTION
according to http://stackoverflow.com/questions/41966066/jboss-interceptor-api-1-1-not-found-when-added-as-sbt-dependency