### PR TITLE
allow multple comments in a line for the new compact syntax

### DIFF
--- a/base/src/test/scala/co/uproot/abandon/ParserTest.scala
+++ b/base/src/test/scala/co/uproot/abandon/ParserTest.scala
@@ -74,7 +74,7 @@ class ParserTest extends FlatSpec with Matchers with Inside {
   def unaryNegExpr(e1: Expr, pos: Option[InputPosition] = None) = {
     UnaryNegExpr(e1)(pos)
   }
-  
+
   it should "parse a simple transaction" in {
     implicit val testInput = """
     2013/1/2
@@ -582,6 +582,31 @@ class ParserTest extends FlatSpec with Matchers with Inside {
                   case List(Post(acc1, expr1, _)) =>
                     acc1 should be (cashAccount)
                     expr1 should be (Some(addExpr(nlit(900), identifierExpr("tax"))))
+                }
+            }
+        }
+    }
+  }
+
+  it should "parse compact transactions with multiple comments in a line" in {
+    val testInput = """
+                      |def defaultAccount = bank
+                      |def tax = 0.1
+                      |. 2016/May/1 Expense        100 * tax            ; multiple ; comments ; in a line
+                    """.stripMargin
+
+    val parseResult = parser.abandon(scanner(testInput))
+
+    inside(parseResult) {
+      case parser.Success(result, _) =>
+        inside(result.entries) {
+          case List(_, _, txnGroup1) =>
+            inside(txnGroup1) {
+              case Transaction(_, _, posts, None, None, comments) =>
+                comments should be(List(" comments ", " in a line"))
+                inside(posts) {
+                  case List(Post(_, _, commentOpt)) =>
+                    commentOpt should be (Some(" multiple "))
                 }
             }
         }


### PR DESCRIPTION
- extended parser for compact transaction syntax to allow multple comments
- added test case for multiple comments in a line