### PR TITLE
Adds OSX dock options

### DIFF
--- a/tools/abandon_gui.sh
+++ b/tools/abandon_gui.sh
@@ -11,7 +11,7 @@ EXTRA_OPTIONS=""
 if [ "$(uname -s)" == "Darwin" ]
 then
   # The dock name won't actually work until https://bugs.openjdk.java.net/browse/JDK-8029440 is fixed
-  EXTRA_OPTIONS='-Xdock:icon=abandon.png -Xdock:name=Abandon -Dcom.apple.mrj.application.apple.menu.about.name=Abandon -Dapple.awt.application.name=Abandon'
+  EXTRA_OPTIONS='-Xdock:icon=ledger.png -Xdock:name=Abandon -Dcom.apple.mrj.application.apple.menu.about.name=Abandon -Dapple.awt.application.name=Abandon'
 fi
 
 $JAVA_CMD ${EXTRA_OPTIONS} -jar ${BASEDIR}/lib/abandon.jar -g $*

--- a/tools/abandon_gui.sh
+++ b/tools/abandon_gui.sh
@@ -7,4 +7,11 @@ fi
 
 BASEDIR=`dirname $0`
 
-$JAVA_CMD -jar ${BASEDIR}/lib/abandon.jar -g $*
+EXTRA_OPTIONS=""
+if [ "$(uname -s)" == "Darwin" ]
+then
+  # The dock name won't actually work until https://bugs.openjdk.java.net/browse/JDK-8029440 is fixed
+  EXTRA_OPTIONS='-Xdock:icon=abandon.png -Xdock:name=Abandon -Dcom.apple.mrj.application.apple.menu.about.name=Abandon -Dapple.awt.application.name=Abandon'
+fi
+
+$JAVA_CMD ${EXTRA_OPTIONS} -jar ${BASEDIR}/lib/abandon.jar -g $*


### PR DESCRIPTION
I got tired of seeing the Java icon in my dock. This little change adds a nice icon.

However, I can't quite figure out where to put the icon so that it gets included in the release archive. I can't quite figure out how you're producing the archive, either! So, here's the image. Maybe you can put it in place so that it is included in the same directory as `abandon_gui.sh`.

![ledger](https://user-images.githubusercontent.com/197224/27802350-57ba7d9a-5ff1-11e7-9302-8c91203ba8c7.png)
