### PR TITLE
Add amount selection and statistics to header

### DIFF
--- a/web-ui/src/lib/components/AmountView.svelte
+++ b/web-ui/src/lib/components/AmountView.svelte
@@ -1,12 +1,55 @@
 <script lang="ts">
+  import { onDestroy } from 'svelte';
+  import { selectedAmounts } from '$lib/stores';
+
   export let amount: string
+
+  const id = crypto.randomUUID();
+  let isSelected = false;
+
+  function handleClick(event: MouseEvent) {
+    if (event.ctrlKey || event.metaKey) {
+      isSelected = !isSelected;
+      if (isSelected) {
+        $selectedAmounts = [...$selectedAmounts, { id, amount }];
+      } else {
+        $selectedAmounts = $selectedAmounts.filter(a => a.id !== id);
+      }
+    }
+  }
+
+  $: {
+    if ($selectedAmounts.length === 0 && isSelected) {
+      isSelected = false;
+    } else if (isSelected && !$selectedAmounts.some(a => a.id === id)) {
+      isSelected = false;
+    }
+  }
+
+  onDestroy(() => {
+    if (isSelected) {
+      selectedAmounts.update(amounts => amounts.filter(a => a.id !== id));
+    }
+  });
 </script>
 
-<span class:subdued={amount == "0.00"}>{amount}</span>
+<!-- svelte-ignore a11y_click_events_have_key_events -->
+<!-- svelte-ignore a11y_no_static_element_interactions -->
+<span
+  class:subdued={amount == "0.00" && !isSelected}
+  class:selected={isSelected}
+  on:click={handleClick}
+>{amount}</span>
 
 <style>
   .subdued {
     opacity: 0.2;
   }
+  .selected {
+    background-color: #5555aa; /* subtle blue */
+    color: #ffffff;
+    border-radius: 3px;
+    padding: 1px 3px;
+    cursor: pointer;
+  }
 </style>
-

--- a/web-ui/src/lib/components/MainPage.svelte
+++ b/web-ui/src/lib/components/MainPage.svelte
@@ -13,6 +13,7 @@
   let avg = 0;
   let min = 0;
   let max = 0;
+  let count = 0;
 
   $: {
     if ($selectedAmounts.length > 0) {
@@ -29,8 +30,9 @@
       }
 
       if (!statsError && values.length > 0) {
+        count = values.length;
         sum = values.reduce((a, b) => a + b, 0);
-        avg = sum / values.length;
+        avg = sum / count;
         min = Math.min(...values);
         max = Math.max(...values);
       }
@@ -83,6 +85,7 @@
         {#if statsError}
           <span class="error">Error parsing amounts</span>
         {:else}
+          <span>[{count}]</span>
           <span>Sum: {sum.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}</span>
           <span>Avg: {avg.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}</span>
           <span>Min: {min.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}</span>

--- a/web-ui/src/lib/components/MainPage.svelte
+++ b/web-ui/src/lib/components/MainPage.svelte
@@ -4,8 +4,42 @@
   import type { Application } from "$lib/model/Application";
   import { TabType, BalanceTabInfo, type TabInfo, AccountTabInfo, MonthlyRegisterTabInfo } from '$lib/model/Tabs';
   import MonthlyRegisterView from './MonthlyRegisterView.svelte';
+  import { selectedAmounts } from '$lib/stores';
 
   export let application: Application
+
+  let statsError = false;
+  let sum = 0;
+  let avg = 0;
+  let min = 0;
+  let max = 0;
+
+  $: {
+    if ($selectedAmounts.length > 0) {
+      statsError = false;
+      let values = [];
+      for (const sa of $selectedAmounts) {
+        // Remove commas before parsing
+        const val = parseFloat(sa.amount.replace(/,/g, ''));
+        if (isNaN(val)) {
+          statsError = true;
+          break;
+        }
+        values.push(val);
+      }
+
+      if (!statsError && values.length > 0) {
+        sum = values.reduce((a, b) => a + b, 0);
+        avg = sum / values.length;
+        min = Math.min(...values);
+        max = Math.max(...values);
+      }
+    }
+  }
+
+  function clearSelection() {
+    $selectedAmounts = [];
+  }
 
   let tabs: TabInfo[] = [
     new BalanceTabInfo(),
@@ -30,18 +64,34 @@
 </script>
 
 <div>
-  <ul>
-    {#each tabs as tab, index}
-    <li class:selected={index == currentTabIndex}>
-      <div>
-      <span on:click={() => currentTabIndex = index}>{tab.getTitle()}</span>
-      {#if tab.closeable}
-        <span class="closeButton" on:click={() => closeTab(index)}>X</span>
-      {/if}
+  <div class="header">
+    <ul>
+      {#each tabs as tab, index}
+      <li class:selected={index == currentTabIndex}>
+        <div>
+        <span on:click={() => currentTabIndex = index}>{tab.getTitle()}</span>
+        {#if tab.closeable}
+          <span class="closeButton" on:click={() => closeTab(index)}>X</span>
+        {/if}
+        </div>
+      </li>
+      {/each}
+    </ul>
+
+    {#if $selectedAmounts.length > 0}
+      <div class="stats">
+        {#if statsError}
+          <span class="error">Error parsing amounts</span>
+        {:else}
+          <span>Sum: {sum.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}</span>
+          <span>Avg: {avg.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}</span>
+          <span>Min: {min.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}</span>
+          <span>Max: {max.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}</span>
+        {/if}
+        <button on:click={clearSelection} title="Deselect all">X</button>
       </div>
-    </li>
-    {/each}
-  </ul>
+    {/if}
+  </div>
 
   <div class="contents">
     {#if currentTab.tabType == TabType.Balance}
@@ -58,16 +108,47 @@
 </div>
 
 <style>
-  ul {
-    display: flex;
-    flex-wrap: wrap;
-    padding: 0;
-
-    position:sticky;
+  .header {
+    position: sticky;
     top: 0px;
     background-color: #0007;
     backdrop-filter: blur(.3em);
     z-index: 10;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+  }
+  .stats {
+    display: flex;
+    gap: 1em;
+    padding: 0.5em 1em;
+    background-color: #222;
+    border: 1px solid #444;
+    border-radius: 4px;
+    margin-right: 1em;
+    color: #eee;
+    font-family: monospace;
+    align-items: center;
+  }
+  .stats .error {
+    color: #ff5555;
+  }
+  .stats button {
+    background: #444;
+    border: none;
+    color: white;
+    cursor: pointer;
+    border-radius: 3px;
+    padding: 2px 6px;
+    font-size: 0.9em;
+  }
+  .stats button:hover {
+    background: #666;
+  }
+  ul {
+    display: flex;
+    flex-wrap: wrap;
+    padding: 0;
     margin: 0;
   }
   li {

--- a/web-ui/src/lib/stores.ts
+++ b/web-ui/src/lib/stores.ts
@@ -1,0 +1,8 @@
+import { writable } from 'svelte/store';
+
+export type SelectedAmount = {
+    id: string;
+    amount: string;
+};
+
+export const selectedAmounts = writable<SelectedAmount[]>([]);

--- a/web-ui/src/routes/+page.svelte
+++ b/web-ui/src/routes/+page.svelte
@@ -2,21 +2,34 @@
   import { dev } from "$app/environment";
   import MainPage from "$lib/components/MainPage.svelte";
   import type { Application } from "$lib/model/Application";
-  import { onMount } from "svelte";
+  import { onMount, onDestroy } from "svelte";
+  import { selectedAmounts } from "$lib/stores";
+  import { get } from "svelte/store";
 
   let application: Application | null = null
 
   const URL = dev ? "/sample.json" : "/api/"
 
+  let timeoutId: number | null = null;
+
   async function fetchAndUpdate() {
-    const result = await fetch(URL)
-    const json = await result.json()
-    application = json;
-    setTimeout(fetchAndUpdate, 4_000)
+    if (get(selectedAmounts).length === 0) {
+      const result = await fetch(URL)
+      const json = await result.json()
+      application = json;
+    }
+    // Note: use window.setTimeout to avoid type issues with NodeJS.Timeout in browser context
+    timeoutId = window.setTimeout(fetchAndUpdate, 4_000);
   }
 
   onMount(async () => {
     fetchAndUpdate()
+  })
+
+  onDestroy(() => {
+    if (timeoutId) {
+      clearTimeout(timeoutId);
+    }
   })
 
 </script>

--- a/web-ui/static/sample.json
+++ b/web-ui/static/sample.json
@@ -1,0 +1,44 @@
+{
+  "accountBalances": [
+    {
+      "name": "Assets",
+      "opening": "0.00",
+      "debit": "100.00",
+      "credit": "0.00",
+      "closing": "100.00",
+      "hasChildren": true,
+      "children": [
+        {
+          "name": "Cash",
+          "opening": "0.00",
+          "debit": "100.00",
+          "credit": "0.00",
+          "closing": "100.00",
+          "hasChildren": false,
+          "children": []
+        }
+      ]
+    },
+    {
+      "name": "Expenses",
+      "opening": "0.00",
+      "debit": "50.00",
+      "credit": "0.00",
+      "closing": "50.00",
+      "hasChildren": true,
+      "children": [
+        {
+          "name": "Food",
+          "opening": "0.00",
+          "debit": "50.00",
+          "credit": "0.00",
+          "closing": "50.00",
+          "hasChildren": false,
+          "children": []
+        }
+      ]
+    }
+  ],
+  "accountTxns": {},
+  "monthlySummaries": []
+}


### PR DESCRIPTION
Implemented a feature allowing users to Ctrl+click amount views to select them. Selected amounts are highlighted, and their statistics (Sum, Average, Min, Max) are displayed in the sticky header. Data polling is paused while amounts are selected.

---
*PR created automatically by Jules for task [15274759524880506902](https://jules.google.com/task/15274759524880506902) started by @hrj*