### PR TITLE
feat(ui): display message for accounts with no transactions

### DIFF
--- a/web-ui/src/lib/components/AccountTab.svelte
+++ b/web-ui/src/lib/components/AccountTab.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import type { AccountTransactions } from '$lib/model/Application';
   import TxnGroupView from './TxnGroupView.svelte';
-
+  import AmountView from './AmountView.svelte';
 
   export let accountName: String
   export let accountTxns: AccountTransactions
@@ -9,13 +9,17 @@
 </script>
 
 <h4>{accountName}</h4>
-<table>
-  <tbody>
-  {#each accountTxns.txnsByMonth as monthlyTxns}
-  <TxnGroupView name={monthlyTxns.name} group={monthlyTxns} txns={monthlyTxns.txns} {onFocusAccount}/>
-  {/each}
-  </tbody>
-</table>
+{#if !accountTxns || !accountTxns.txnsByMonth || accountTxns.txnsByMonth.length === 0}
+  <p>No transactions in this account. Balance: <AmountView amount={accountTxns ? accountTxns.closing : "0.00"} /></p>
+{:else}
+  <table>
+    <tbody>
+    {#each accountTxns.txnsByMonth as monthlyTxns}
+    <TxnGroupView name={monthlyTxns.name} group={monthlyTxns} txns={monthlyTxns.txns} {onFocusAccount}/>
+    {/each}
+    </tbody>
+  </table>
+{/if}
 
 <style>
 </style>


### PR DESCRIPTION
Modified `AccountTab.svelte` to check if `accountTxns.txnsByMonth` is empty or undefined. If it is, it renders a friendly message using `AmountView` to display the closing balance, instead of just an empty table.

---
*PR created automatically by Jules for task [5095868263337885942](https://jules.google.com/task/5095868263337885942) started by @hrj*