### PR TITLE
🧪 Add comprehensive tests for `allUnique` in Helper.scala

### DIFF
--- a/base/src/test/scala/co/uproot/abandon/HelperTest.scala
+++ b/base/src/test/scala/co/uproot/abandon/HelperTest.scala
@@ -1,0 +1,30 @@
+package co.uproot.abandon
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class HelperTest extends AnyFlatSpec with Matchers {
+
+  "allUnique" should "return None for empty collections" in {
+    Helper.allUnique(Seq.empty[Int]) shouldBe None
+    Helper.allUnique(List.empty[String]) shouldBe None
+  }
+
+  it should "return None for collections with all unique elements" in {
+    Helper.allUnique(Seq(1, 2, 3, 4, 5)) shouldBe None
+    Helper.allUnique(List("a", "b", "c")) shouldBe None
+    Helper.allUnique(Set(1, 2, 3)) shouldBe None
+    Helper.allUnique(Iterator(1, 2, 3, 4)) shouldBe None
+  }
+
+  it should "return Some(element) for collections with duplicate elements" in {
+    Helper.allUnique(Seq(1, 2, 3, 2, 4)) shouldBe Some(2)
+    Helper.allUnique(List("a", "b", "c", "a")) shouldBe Some("a")
+    Helper.allUnique(Iterator(1, 2, 1, 3)) shouldBe Some(1)
+  }
+
+  it should "return the first non-unique element" in {
+    Helper.allUnique(Seq(1, 2, 3, 2, 4, 3)) shouldBe Some(2)
+    Helper.allUnique(List("a", "b", "c", "b", "a")) shouldBe Some("b")
+  }
+}


### PR DESCRIPTION
🎯 **What:** The `allUnique` function in `Helper.scala` (which checks if elements in an `IterableOnce` collection are unique) lacked unit test coverage. This PR introduces a new test suite to thoroughly cover its behavior.

📊 **Coverage:** The new tests in `HelperTest.scala` cover the following scenarios:
* Empty collections (`Seq`, `List`)
* Collections with all unique elements (`Seq`, `List`, `Set`, `Iterator`)
* Collections with duplicate elements, verifying it returns `Some(first non-unique element)`
* Collections with multiple duplicates, verifying it returns the first non-unique element encountered.

✨ **Result:** Test coverage for `Helper.allUnique` is significantly improved, ensuring the function accurately identifies the first non-unique element and handles edge cases like empty inputs robustly.

---
*PR created automatically by Jules for task [8263267005950038608](https://jules.google.com/task/8263267005950038608) started by @hrj*