### PR TITLE
🔒 Prevent Exception Details Leak in 500 Response

### DIFF
--- a/cli/src/main/java/org/limium/picoserve/Server.java
+++ b/cli/src/main/java/org/limium/picoserve/Server.java
@@ -115,7 +115,7 @@ public final class Server {
                 response = handler.processor.process(new Request(exchange));
               } catch (final Exception e) {
                 e.printStackTrace();
-                response = new StringResponse(500, "Error: " + e);
+                response = new StringResponse(500, "Internal Server Error");
               }
             }
             final var headersToSend = response.getResponseHeaders();


### PR DESCRIPTION
🎯 **What:** Fixed an Information Leak vulnerability where raw exception details were being exposed to HTTP clients in 500 Internal Server Error responses.

⚠️ **Risk:** Leaking exception details (such as stack traces or internal state messages) to users can help attackers glean information about the server environment, architecture, and potentially sensitive internal variables. This corresponds to CWE-209.

🛡️ **Solution:** Modified the 500 error response generation in `Server.java` to return a generic "Internal Server Error" message instead of the exception details, while keeping `e.printStackTrace()` to log the error on the server side for debugging.

---
*PR created automatically by Jules for task [5972526327476462177](https://jules.google.com/task/5972526327476462177) started by @hrj*